### PR TITLE
Take in shr-text-import 4.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "mkdirp": "^0.5.1",
     "shr-models": "~4.1.0",
     "shr-expand": "~4.1.0",
-    "shr-text-import": "~4.1.0",
+    "shr-text-import": "~4.1.1",
     "shr-md-export": "~4.1.0",
     "shr-json-export": "~4.1.0",
     "shr-fhir-export": "~4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -93,9 +93,9 @@ shr-models@~4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-4.1.0.tgz#940d6037181d2e57cfd176d001bb8333434562c4"
 
-shr-text-import@~4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/shr-text-import/-/shr-text-import-4.1.0.tgz#02950cf8e64f2ab7cff3ec93da315888ce9be846"
+shr-text-import@~4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/shr-text-import/-/shr-text-import-4.1.1.tgz#00c87369f7c69c2223fa6702d648186779ae2710"
   dependencies:
     antlr4 "~4.5.3"
     shr-models "~4.1.0"


### PR DESCRIPTION
Need shr-text-import 4.1.1 to fix the bug with rejecting files that declare the 4.1 grammar.