### PR TITLE
Update IGPublisher Commands to Use New Tx Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,12 @@ Next, create the IG using the HL7 IG Publisher Tool.
 
 On Mac or Linux:
 ```
-$ java -jar $JAVA_OPTS out/fhir/guide/org.hl7.fhir.igpublisher.jar -ig out/fhir/guide/shr.json
+$ java -jar $JAVA_OPTS out/fhir/guide/org.hl7.fhir.igpublisher.jar -ig out/fhir/guide/shr.json -tx http://test.fhir.org/r3
 ```
 
 On Windows:
 ```
-> java -jar %JAVA_OPTS% out/fhir/guide/org.hl7.fhir.igpublisher.jar -ig out/fhir/guide/shr.json
+> java -jar %JAVA_OPTS% out/fhir/guide/org.hl7.fhir.igpublisher.jar -ig out/fhir/guide/shr.json -tx http://test.fhir.org/r3
 ```
 
 # License

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "main": "app.js",
   "scripts": {
-    "ig:publish": "java -jar ./out/fhir/guide/org.hl7.fhir.igpublisher.jar -ig ./out/fhir/guide/shr.json; ./node_modules/.bin/replace-in-file /âˆ‘/g Σ ./out/fhir/guide/output/guide/StructureDefinition-*.html --isRegex",
+    "ig:publish": "java -jar ./out/fhir/guide/org.hl7.fhir.igpublisher.jar -ig ./out/fhir/guide/shr.json -tx http://test.fhir.org/r3",
     "lint": "./node_modules/.bin/eslint .",
     "lint:fix": "./node_modules/.bin/eslint . --fix"
   },


### PR DESCRIPTION
This is necessary since the FHIR transaction server was moved.