### PR TITLE
Bump shr-fhir-export to 4.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-cli",
-  "version": "4.3.3",
+  "version": "4.3.4",
   "description": "Command-line interface for SHR tools",
   "author": "",
   "license": "Apache-2.0",
@@ -20,7 +20,7 @@
     "commander": "^2.9.0",
     "mkdirp": "^0.5.1",
     "shr-expand": "^4.2.1",
-    "shr-fhir-export": "^4.2.3",
+    "shr-fhir-export": "^4.2.4",
     "shr-json-export": "^4.3.2",
     "shr-md-export": "^4.1.2",
     "shr-models": "^4.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -181,9 +181,9 @@ shr-expand@^4.2.1:
     bunyan "^1.8.9"
     shr-models "^4.2.1"
 
-shr-fhir-export@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-4.2.3.tgz#18ab3870203a46f41a40607c2cecde1605b8b61c"
+shr-fhir-export@^4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-4.2.4.tgz#859ff2843caf546de33478d46b018181dde8dbc7"
   dependencies:
     bunyan "^1.8.9"
     fs-extra "^2.0.0"


### PR DESCRIPTION
This takes in a fix related to the FHIR mapping crashing when there are recursive elements in paths.