### PR TITLE
Update shr-fhir-exporter to beta 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-cli",
-  "version": "5.0.0-beta.4",
+  "version": "5.0.0-beta.6",
   "description": "Command-line interface for SHR tools",
   "author": "",
   "license": "Apache-2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -182,8 +182,8 @@ shr-expand@beta:
     shr-models beta
 
 shr-fhir-export@beta:
-  version "5.0.0-beta.4"
-  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.0.0-beta.4.tgz#75acaf24c6fba4211489d07b99e171b9768cbe43"
+  version "5.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.0.0-beta.5.tgz#b820b4d27491d2592cb8c070c3379e9ff8f52153"
   dependencies:
     bunyan "^1.8.9"
     fs-extra "^2.0.0"


### PR DESCRIPTION
Takes in fix regarding links to FHIR 1.8 resources instead of FHIR 3.0.1 resources.