### PR TITLE
Update shr-fhir-export to 5.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-cli",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Command-line interface for SHR tools",
   "author": "",
   "license": "Apache-2.0",
@@ -20,7 +20,7 @@
     "commander": "^2.9.0",
     "mkdirp": "^0.5.1",
     "shr-expand": "^5.0.0",
-    "shr-fhir-export": "^5.0.0",
+    "shr-fhir-export": "^5.0.1",
     "shr-json-export": "^5.0.0",
     "shr-models": "^5.0.0",
     "shr-text-import": "^5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -151,9 +151,9 @@ shr-expand@^5.0.0:
     bunyan "^1.8.9"
     shr-models "^5.0.0"
 
-shr-fhir-export@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.0.0.tgz#98310ba740b368b3ec82f1893a5a7b54876419cf"
+shr-fhir-export@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.0.1.tgz#d81b79e3db55db00fdb5ff6ea27cfc20badcd2c0"
   dependencies:
     bunyan "^1.8.9"
     fs-extra "^2.0.0"


### PR DESCRIPTION
Fixes crashes that occur in use cases with very few explicit mappings, resulting in many profiles on Basic and many extensions.