### PR TITLE
Implemented sanity checking for conflicting versions of shr-models

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,12 +4,15 @@ const mkdirp = require('mkdirp');
 const bunyan = require('bunyan');
 const program = require('commander');
 const bps = require('@ojolabs/bunyan-prettystream');
+const { sanityCheckModules } = require('shr-models');
 const shrTI = require('shr-text-import');
 const shrEx = require('shr-expand');
 const shrJE = require('shr-json-export');
 const shrFE = require('shr-fhir-export');
 
 /* eslint-disable no-console */
+
+sanityCheckModules({shrTI, shrEx, shrJE, shrFE })
 
 // Record the time so we can print elapsed time
 const hrstart = process.hrtime();

--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
     "bunyan": "^1.8.9",
     "commander": "^2.9.0",
     "mkdirp": "^0.5.1",
-    "shr-expand": "^5.1.0",
-    "shr-fhir-export": "^5.2.0",
-    "shr-json-export": "^5.1.1",
-    "shr-models": "^5.1.0",
-    "shr-text-import": "^5.2.0"
+    "shr-expand": "https://github.com/standardhealth/shr-expand#sanity-check",
+    "shr-fhir-export": "https://github.com/standardhealth/shr-fhir-export#sanity-check",
+    "shr-json-export": "https://github.com/standardhealth/shr-json-export#sanity-check",
+    "shr-models": "https://github.com/standardhealth/shr-models#sanity-check",
+    "shr-text-import": "https://github.com/standardhealth/shr-text-import#sanity-check"
   },
   "devDependencies": {
     "eslint": "^4.6.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-cli",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Command-line interface for SHR tools",
   "author": "",
   "license": "Apache-2.0",
@@ -19,11 +19,11 @@
     "bunyan": "^1.8.9",
     "commander": "^2.9.0",
     "mkdirp": "^0.5.1",
-    "shr-expand": "https://github.com/standardhealth/shr-expand#sanity-check",
-    "shr-fhir-export": "https://github.com/standardhealth/shr-fhir-export#sanity-check",
-    "shr-json-export": "https://github.com/standardhealth/shr-json-export#sanity-check",
-    "shr-models": "https://github.com/standardhealth/shr-models#sanity-check",
-    "shr-text-import": "https://github.com/standardhealth/shr-text-import#sanity-check"
+    "shr-expand": "^5.2.0",
+    "shr-fhir-export": "^5.2.1",
+    "shr-json-export": "^5.1.2",
+    "shr-models": "^5.2.0",
+    "shr-text-import": "^5.2.1"
   },
   "devDependencies": {
     "eslint": "^4.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -782,39 +782,39 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
-shr-expand@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.1.0.tgz#4f3fa3cd182dfe731220bb68583c542c2fb22b82"
+shr-expand@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.2.0.tgz#378d3cc20d4f51413fbfcb4fc0418b338003e901"
   dependencies:
     bunyan "^1.8.9"
-    shr-models "^5.1.0"
+    shr-models "^5.2.0"
 
-shr-fhir-export@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.2.0.tgz#b4c54bf190931177a5b994ef5bf1b0d3b54e079b"
+shr-fhir-export@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.2.1.tgz#d938c0783c94ba74c9e32af6e0285ecc8491374c"
   dependencies:
     bunyan "^1.8.9"
     fs-extra "^2.0.0"
-    shr-models "^5.1.0"
+    shr-models "^5.2.0"
 
-shr-json-export@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/shr-json-export/-/shr-json-export-5.1.1.tgz#b2dd3af1503fa0a416da697962adb0a1a7a5933f"
+shr-json-export@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/shr-json-export/-/shr-json-export-5.1.2.tgz#e5d4271dc4a5cc728b2a42ecee255101d964f384"
   dependencies:
     bunyan "^1.8.9"
-    shr-models "^5.1.0"
+    shr-models "^5.2.0"
 
-shr-models@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.1.0.tgz#3f9ef0e7ba929ea440fd07f2f31f905866ac4e03"
-
-shr-text-import@^5.2.0:
+shr-models@^5.2.0:
   version "5.2.0"
-  resolved "https://registry.yarnpkg.com/shr-text-import/-/shr-text-import-5.2.0.tgz#c37c4f838ee87b9fb9f717916062782a336704fd"
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.2.0.tgz#3dba6f113f65a16250de2012f6e4d4bbf692e0ed"
+
+shr-text-import@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/shr-text-import/-/shr-text-import-5.2.1.tgz#71e803e94733b33c9ad0244f38586ec4ee068ba9"
   dependencies:
     antlr4 "~4.6.0"
     bunyan "^1.8.9"
-    shr-models "^5.1.0"
+    shr-models "^5.2.0"
 
 signal-exit@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
Added sanity checking support for different versions of `shr-models`.

The one enhancement that I thought of after finishing this was making the sanity check ignore modules that were being skipped on the command line with `-s`.