### PR TITLE
Take in shr-fhir-export 5.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-cli",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "description": "Command-line interface for SHR tools",
   "author": "",
   "license": "Apache-2.0",
@@ -20,7 +20,7 @@
     "commander": "^2.9.0",
     "mkdirp": "^0.5.1",
     "shr-expand": "^5.2.0",
-    "shr-fhir-export": "^5.2.1",
+    "shr-fhir-export": "5.2.2",
     "shr-json-export": "^5.1.2",
     "shr-models": "^5.2.0",
     "shr-text-import": "^5.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -789,9 +789,9 @@ shr-expand@^5.2.0:
     bunyan "^1.8.9"
     shr-models "^5.2.0"
 
-shr-fhir-export@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.2.1.tgz#d938c0783c94ba74c9e32af6e0285ecc8491374c"
+shr-fhir-export@5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.2.2.tgz#1e4df8b3471251d3c2ce1d9084e7781a3b65298c"
   dependencies:
     bunyan "^1.8.9"
     fs-extra "^2.0.0"


### PR DESCRIPTION
This fixes a bug with applying constraints to extensions, updates US Core to 1.0.1, and provides more graceful handling of unexpected errors in shr-fhir-export.