### PR TITLE
FHIR "No diff profiles" and Peer models

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-cli",
-  "version": "5.2.3",
+  "version": "5.3.0",
   "description": "Command-line interface for SHR tools",
   "author": "",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -16,14 +16,14 @@
   },
   "dependencies": {
     "@ojolabs/bunyan-prettystream": "^0.1.6",
-    "bunyan": "^1.8.9",
+    "bunyan": "^1.8.12",
     "commander": "^2.9.0",
     "mkdirp": "^0.5.1",
-    "shr-expand": "5.2.1",
-    "shr-fhir-export": "5.2.2",
-    "shr-json-export": "^5.1.2",
-    "shr-models": "^5.2.0",
-    "shr-text-import": "^5.2.1"
+    "shr-expand": "^5.2.3",
+    "shr-fhir-export": "^5.3.1",
+    "shr-json-export": "^5.1.3",
+    "shr-models": "^5.2.1",
+    "shr-text-import": "^5.2.2"
   },
   "devDependencies": {
     "eslint": "^4.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,20 +94,9 @@ babel-code-frame@^6.22.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-balanced-match@^0.4.1:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
-
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
-
-brace-expansion@^1.0.0:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.6.tgz#7197d7eaa9b87e648390ea61fc66c84427420df9"
-  dependencies:
-    balanced-match "^0.4.1"
-    concat-map "0.0.1"
 
 brace-expansion@^1.1.7:
   version "1.1.8"
@@ -116,9 +105,9 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-bunyan@^1.8.9:
-  version "1.8.9"
-  resolved "https://registry.yarnpkg.com/bunyan/-/bunyan-1.8.9.tgz#2c7c9d422ea64ee2465d52b4decd72de0657401a"
+bunyan@^1.8.12:
+  version "1.8.12"
+  resolved "https://registry.yarnpkg.com/bunyan/-/bunyan-1.8.12.tgz#f150f0f6748abdd72aeae84f04403be2ef113797"
   optionalDependencies:
     dtrace-provider "~0.8"
     moment "^2.10.6"
@@ -241,8 +230,8 @@ doctrine@^2.0.0:
     isarray "^1.0.0"
 
 dtrace-provider@~0.8:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/dtrace-provider/-/dtrace-provider-0.8.1.tgz#cd4d174a233bea1bcf4a1fbfa5798f44f48cda9f"
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/dtrace-provider/-/dtrace-provider-0.8.5.tgz#98ebba221afac46e1c39fd36858d8f9367524b92"
   dependencies:
     nan "^2.3.3"
 
@@ -575,13 +564,7 @@ mimic-fn@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
 
-"minimatch@2 || 3":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
-  dependencies:
-    brace-expansion "^1.0.0"
-
-minimatch@^3.0.2, minimatch@^3.0.4:
+"minimatch@2 || 3", minimatch@^3.0.2, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -598,8 +581,8 @@ mkdirp@^0.5.1, mkdirp@~0.5.1:
     minimist "0.0.8"
 
 moment@^2.10.6:
-  version "2.18.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
+  version "2.19.3"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.3.tgz#bdb99d270d6d7fda78cc0fbace855e27fe7da69f"
 
 ms@2.0.0:
   version "2.0.0"
@@ -618,8 +601,8 @@ mv@~2:
     rimraf "~2.4.0"
 
 nan@^2.3.3:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.5.1.tgz#d5b01691253326a97a2bbee9e61c55d8d60351e2"
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.8.0.tgz#ed715f3fe9de02b57a5e6252d90a96675e1f085a"
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -782,39 +765,29 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
-shr-expand@5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.2.1.tgz#a1165544c730f656f19419ea361064ec096a3fb7"
-  dependencies:
-    bunyan "^1.8.9"
-    shr-models "^5.2.0"
+shr-expand@^5.2.3:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.2.3.tgz#b99d3d42691a31fa321c0aac22b5e0b1ffff7ade"
 
-shr-fhir-export@5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.2.2.tgz#1e4df8b3471251d3c2ce1d9084e7781a3b65298c"
+shr-fhir-export@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.3.1.tgz#8e5ce597d5ff0e30494e737fe33a157f75193aeb"
   dependencies:
-    bunyan "^1.8.9"
     fs-extra "^2.0.0"
-    shr-models "^5.2.0"
 
-shr-json-export@^5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/shr-json-export/-/shr-json-export-5.1.2.tgz#e5d4271dc4a5cc728b2a42ecee255101d964f384"
-  dependencies:
-    bunyan "^1.8.9"
-    shr-models "^5.2.0"
+shr-json-export@^5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/shr-json-export/-/shr-json-export-5.1.3.tgz#ea99fd3bfeb47562f122488748c05f0e10fcb3a0"
 
-shr-models@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.2.0.tgz#3dba6f113f65a16250de2012f6e4d4bbf692e0ed"
-
-shr-text-import@^5.2.1:
+shr-models@^5.2.1:
   version "5.2.1"
-  resolved "https://registry.yarnpkg.com/shr-text-import/-/shr-text-import-5.2.1.tgz#71e803e94733b33c9ad0244f38586ec4ee068ba9"
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.2.1.tgz#23108d369a0be9fa2518d9be4c1e53685d9dd776"
+
+shr-text-import@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/shr-text-import/-/shr-text-import-5.2.2.tgz#bb4894dbb857ede614c156f5fc7ba2c3bfc41d05"
   dependencies:
     antlr4 "~4.6.0"
-    bunyan "^1.8.9"
-    shr-models "^5.2.0"
 
 signal-exit@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
This updates the `shr-fhir-export` dependency to bring in the version that introduces the concept of "no diff profiles".  In short, this means that if an element maps cleanly to its FHIR target (e.g., there is no structural or constraint-related diff), then no profile is produced.

This also updates `shr-expand` and `shr-models` to new versions with bug fixes.

Lastly, _all_ shr-related libraries are updated to versions that declare `shr-models` and `bunyan` as _peer dependencies_.  This ensures that only a single instance of those libraries is used when invoking the SHR CLI, and eliminates potential version mismatch problems.