### PR TITLE
Dec8 bug fixes

### DIFF
--- a/logcounter.js
+++ b/logcounter.js
@@ -1,0 +1,64 @@
+const { EventEmitter } = require('events');
+const { TRACE, DEBUG, INFO, WARN, ERROR, FATAL } = require('bunyan');
+
+/**
+ * LogCounter simply counts the number of each kind of logging statement and the modules that triggered it.
+ * This implementation is loosely based on the RingBuffer implementation.
+ */
+class LogCounter extends EventEmitter {
+  constructor() {
+    super();
+    this._trace = new CountInfo();
+    this._debug = new CountInfo();
+    this._info = new CountInfo();
+    this._warn = new CountInfo();
+    this._error = new CountInfo();
+    this._fatal = new CountInfo();
+  }
+
+  get trace() { return this._trace; }
+  get debug() { return this._debug; }
+  get info() { return this._info; }
+  get warn() { return this._warn; }
+  get error() { return this._error; }
+  get fatal() { return this._fatal; }
+
+  write(record) {
+    switch(record.level) {
+    case TRACE: this._trace.increment(record.module); break;
+    case DEBUG: this._debug.increment(record.module); break;
+    case INFO: this._info.increment(record.module); break;
+    case WARN: this._warn.increment(record.module); break;
+    case ERROR: this._error.increment(record.module); break;
+    case FATAL: this._fatal.increment(record.module); break;
+    }
+    return true;
+  }
+
+  end() {}
+
+  destroy() {
+    this.emit('close');
+  }
+
+  destroySoon() {
+    this.destroy();
+  }
+}
+
+class CountInfo {
+  constructor() {
+    this._count = 0;
+    this._modules = new Map();
+  }
+
+  get count() { return this._count; }
+  get modules() { return Array.from(this._modules.keys()); }
+
+  increment(module) {
+    this._count++;
+    this._modules.set(module, true);
+  }
+}
+
+module.exports = LogCounter;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "commander": "^2.9.0",
     "mkdirp": "^0.5.1",
     "shr-expand": "^5.2.3",
-    "shr-fhir-export": "^5.3.1",
+    "shr-fhir-export": "^5.3.2",
     "shr-json-export": "^5.1.3",
     "shr-models": "^5.2.1",
     "shr-text-import": "^5.2.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-cli",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "Command-line interface for SHR tools",
   "author": "",
   "license": "Apache-2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -769,9 +769,9 @@ shr-expand@^5.2.3:
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.2.3.tgz#b99d3d42691a31fa321c0aac22b5e0b1ffff7ade"
 
-shr-fhir-export@^5.3.1:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.3.1.tgz#8e5ce597d5ff0e30494e737fe33a157f75193aeb"
+shr-fhir-export@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.3.2.tgz#1c1e1ae82d50bc124701c042f54f582a03887852"
   dependencies:
     fs-extra "^2.0.0"
 


### PR DESCRIPTION
This fixes several issues:
- FHIR Exporter was emitting incorrect warnings (and usually too many of them)
- FHIR Exporter was running slow.  It's faster now.
- CLI was reporting the wrong number or warnings and errors (#49)