### PR TITLE
5.3.2: Fix Includes Type and other bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ After exporting the SHR definitions, the FHIR IG Publisher tool can be used to c
 $ yarn run ig:publish
 ```
 
+NOTE: The FHIR IG publishing tool uses a _lot_ of memory when processing the full set of SHR definitions.  The yarn script above will allocated up to 8GB of RAM.
+
 # Creating the FHIR Implementation Guide Using an HTTP Proxy
 
 If your system requires a proxy to access the internet, you'll need to take a more complex approach than above.
@@ -84,12 +86,12 @@ Next, create the IG using the HL7 IG Publisher Tool.
 
 On Mac or Linux:
 ```
-$ java -jar $JAVA_OPTS out/fhir/guide/org.hl7.fhir.igpublisher.jar -ig out/fhir/guide/data.json
+$ java $JAVA_OPTS -Xms4g -Xmx8g -jar out/fhir/guide/org.hl7.fhir.igpublisher.jar -ig out/fhir/guide/data.json
 ```
 
 On Windows:
 ```
-> java -jar %JAVA_OPTS% out/fhir/guide/org.hl7.fhir.igpublisher.jar -ig out/fhir/guide/data.json
+> java %JAVA_OPTS% -Xms4g -Xmx8g -jar out/fhir/guide/org.hl7.fhir.igpublisher.jar -ig out/fhir/guide/data.json
 ```
 
 # License

--- a/app.js
+++ b/app.js
@@ -86,7 +86,7 @@ const expSpecifications = shrEx.expand(specifications, shrFE);
 
 if (doJSON) {
   const jsonHierarchyResults = shrJE.exportToJSON(specifications, configSpecifications);
-  const hierarchyPath = `${program.out}/json/definitons.json`;
+  const hierarchyPath = `${program.out}/json/definitions.json`;
   mkdirp.sync(hierarchyPath.substring(0, hierarchyPath.lastIndexOf('/')));
   fs.writeFileSync(hierarchyPath, JSON.stringify(jsonHierarchyResults, null, '  '));
 } else {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "main": "app.js",
   "scripts": {
-    "ig:publish": "java -jar ./out/fhir/guide/org.hl7.fhir.igpublisher.jar -ig ./out/fhir/guide/data.json",
+    "ig:publish": "java -Xms4g -Xmx8g -jar ./out/fhir/guide/org.hl7.fhir.igpublisher.jar -ig ./out/fhir/guide/data.json",
     "lint": "./node_modules/.bin/eslint .",
     "lint:fix": "./node_modules/.bin/eslint . --fix"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "shr-fhir-export": "^5.3.2",
     "shr-json-export": "^5.1.3",
     "shr-models": "^5.2.1",
-    "shr-text-import": "^5.2.2"
+    "shr-text-import": "^5.2.3"
   },
   "devDependencies": {
     "eslint": "^4.6.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-cli",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "description": "Command-line interface for SHR tools",
   "author": "",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "commander": "^2.9.0",
     "mkdirp": "^0.5.1",
     "shr-expand": "^5.2.3",
-    "shr-fhir-export": "^5.3.2",
+    "shr-fhir-export": "^5.3.3",
     "shr-json-export": "^5.1.3",
-    "shr-models": "^5.2.1",
+    "shr-models": "^5.2.2",
     "shr-text-import": "^5.2.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "commander": "^2.9.0",
     "mkdirp": "^0.5.1",
     "shr-expand": "^5.2.3",
-    "shr-fhir-export": "^5.3.3",
+    "shr-fhir-export": "^5.3.4",
     "shr-json-export": "^5.1.3",
     "shr-models": "^5.2.2",
     "shr-text-import": "^5.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -783,9 +783,9 @@ shr-models@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.2.1.tgz#23108d369a0be9fa2518d9be4c1e53685d9dd776"
 
-shr-text-import@^5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/shr-text-import/-/shr-text-import-5.2.2.tgz#bb4894dbb857ede614c156f5fc7ba2c3bfc41d05"
+shr-text-import@^5.2.3:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/shr-text-import/-/shr-text-import-5.2.3.tgz#0af683af80e1580fc84226b1a9376f075da6dfc3"
   dependencies:
     antlr4 "~4.6.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -769,9 +769,9 @@ shr-expand@^5.2.3:
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.2.3.tgz#b99d3d42691a31fa321c0aac22b5e0b1ffff7ade"
 
-shr-fhir-export@^5.3.2:
-  version "5.3.2"
-  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.3.2.tgz#1c1e1ae82d50bc124701c042f54f582a03887852"
+shr-fhir-export@^5.3.3:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.3.3.tgz#de4129a909a283005be91546e2a9b36762e2c9ce"
   dependencies:
     fs-extra "^2.0.0"
 
@@ -779,9 +779,9 @@ shr-json-export@^5.1.3:
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/shr-json-export/-/shr-json-export-5.1.3.tgz#ea99fd3bfeb47562f122488748c05f0e10fcb3a0"
 
-shr-models@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.2.1.tgz#23108d369a0be9fa2518d9be4c1e53685d9dd776"
+shr-models@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.2.2.tgz#42b9f13deded480628529e22bca09af546f8ba81"
 
 shr-text-import@^5.2.3:
   version "5.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -769,9 +769,9 @@ shr-expand@^5.2.3:
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.2.3.tgz#b99d3d42691a31fa321c0aac22b5e0b1ffff7ade"
 
-shr-fhir-export@^5.3.3:
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.3.3.tgz#de4129a909a283005be91546e2a9b36762e2c9ce"
+shr-fhir-export@^5.3.4:
+  version "5.3.4"
+  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.3.4.tgz#990277d1204bcbd2f18c3a544e5e10a04cc3fa50"
   dependencies:
     fs-extra "^2.0.0"
 


### PR DESCRIPTION
This PR updates shr-models, shr-text-import, and shr-fhir-export to address several bugs:
- incorrect FHIR export of "includes type" constraints (standardhealth/shr-fhir-export#72)
- inability to restrict types to primitives (standardhealth/shr-grammar#27)
- JSON export produces wrong filename (typo)
- FHIR IG crashes due to insufficient memory