### PR TITLE
Added Canonical JSON Exporter

### DIFF
--- a/app.js
+++ b/app.js
@@ -101,8 +101,12 @@ if (doCIMCORE) {
     let fqn = de.identifier.fqn.replace(/\./g, '-');
 
     const hierarchyPath = `${program.out}/cimcore/${namespace}/${fqn}.json`;
-    mkdirp.sync(hierarchyPath.substring(0, hierarchyPath.lastIndexOf('/')));
-    fs.writeFileSync(hierarchyPath, JSON.stringify(de, null, '  '));
+    try {
+      mkdirp.sync(hierarchyPath.substring(0, hierarchyPath.lastIndexOf('/')));
+      fs.writeFileSync(hierarchyPath, JSON.stringify(de, null, '  '));
+      } catch (error) {
+      logger.error('Unable to successfully serialize element %s into CIMCORE, failing with error %s. ERROR_CODE:15001', name, error);
+    }
   }
 
   //valuesets
@@ -111,8 +115,12 @@ if (doCIMCORE) {
     let name = vs.identifier.name.replace(/\./g, '-');;
 
     const hierarchyPath = `${program.out}/cimcore/${namespace}/valuesets/${name}.json`;
-    mkdirp.sync(hierarchyPath.substring(0, hierarchyPath.lastIndexOf('/')));
-    fs.writeFileSync(hierarchyPath, JSON.stringify(vs, null, '  '));
+    try {
+      mkdirp.sync(hierarchyPath.substring(0, hierarchyPath.lastIndexOf('/')));
+      fs.writeFileSync(hierarchyPath, JSON.stringify(vs, null, '  '));
+    } catch (error) {
+      logger.error('Unable to successfully serialize value set %s into CIMCORE, failing with error %s. ERROR_CODE:15002', name, error);
+    }
   }
 
   //mappings
@@ -121,8 +129,12 @@ if (doCIMCORE) {
     let name = mapping.identifier.name;
 
     const hierarchyPath = `${program.out}/cimcore/${namespace}/mappings/${name}-mapping.json`;
-    mkdirp.sync(hierarchyPath.substring(0, hierarchyPath.lastIndexOf('/')));
-    fs.writeFileSync(hierarchyPath, JSON.stringify(mapping, null, '  '));
+    try {
+      mkdirp.sync(hierarchyPath.substring(0, hierarchyPath.lastIndexOf('/')));
+      fs.writeFileSync(hierarchyPath, JSON.stringify(mapping, null, '  '));
+    } catch (error) {
+      logger.error('Unable to successfully serialize mapping %s into CIMCORE, failing with error %s. ERROR_CODE:15003', name, error);
+    }
   }
 
   //meta namespace files
@@ -130,8 +142,12 @@ if (doCIMCORE) {
     let namespace = ns.namespace.replace(/\./, '-');
 
     const hierarchyPath = `${program.out}/cimcore/${namespace}/${namespace}.json`;
-    mkdirp.sync(hierarchyPath.substring(0, hierarchyPath.lastIndexOf('/')));
-    fs.writeFileSync(hierarchyPath, JSON.stringify(ns, null, '  '));
+    try {
+      mkdirp.sync(hierarchyPath.substring(0, hierarchyPath.lastIndexOf('/')));
+      fs.writeFileSync(hierarchyPath, JSON.stringify(ns, null, '  '));
+    } catch (error) {
+      logger.error('Unable to successfully serialize namespace meta information %s into CIMCORE, failing with error %s. ERROR_CODE:15004', namespace, error);
+    }
   }  
 
   //meta project file

--- a/app.js
+++ b/app.js
@@ -105,7 +105,7 @@ if (doCIMCORE) {
       mkdirp.sync(hierarchyPath.substring(0, hierarchyPath.lastIndexOf('/')));
       fs.writeFileSync(hierarchyPath, JSON.stringify(de, null, '  '));
       } catch (error) {
-      logger.error('Unable to successfully serialize element %s into CIMCORE, failing with error %s. ERROR_CODE:15001', name, error);
+      logger.error('Unable to successfully serialize element %s into CIMCORE, failing with error "%s". ERROR_CODE:15001', de.identifier.fqn, error);
     }
   }
 
@@ -119,7 +119,7 @@ if (doCIMCORE) {
       mkdirp.sync(hierarchyPath.substring(0, hierarchyPath.lastIndexOf('/')));
       fs.writeFileSync(hierarchyPath, JSON.stringify(vs, null, '  '));
     } catch (error) {
-      logger.error('Unable to successfully serialize value set %s into CIMCORE, failing with error %s. ERROR_CODE:15002', name, error);
+      logger.error('Unable to successfully serialize value set %s into CIMCORE, failing with error "%s". ERROR_CODE:15002', vs.identifier.fqn, error);
     }
   }
 
@@ -133,7 +133,7 @@ if (doCIMCORE) {
       mkdirp.sync(hierarchyPath.substring(0, hierarchyPath.lastIndexOf('/')));
       fs.writeFileSync(hierarchyPath, JSON.stringify(mapping, null, '  '));
     } catch (error) {
-      logger.error('Unable to successfully serialize mapping %s into CIMCORE, failing with error %s. ERROR_CODE:15003', name, error);
+      logger.error('Unable to successfully serialize mapping %s into CIMCORE, failing with error "%s". ERROR_CODE:15003', mapping.identifier.fqn, error);
     }
   }
 
@@ -146,7 +146,7 @@ if (doCIMCORE) {
       mkdirp.sync(hierarchyPath.substring(0, hierarchyPath.lastIndexOf('/')));
       fs.writeFileSync(hierarchyPath, JSON.stringify(ns, null, '  '));
     } catch (error) {
-      logger.error('Unable to successfully serialize namespace meta information %s into CIMCORE, failing with error %s. ERROR_CODE:15004', namespace, error);
+      logger.error('Unable to successfully serialize namespace meta information %s into CIMCORE, failing with error "%s". ERROR_CODE:15004', namespace, error);
     }
   }  
 

--- a/app.js
+++ b/app.js
@@ -28,7 +28,7 @@ program
   .usage('<path-to-shr-defs> [options]')
   .option('-l, --log-level <level>', 'the console log level <fatal,error,warn,info,debug,trace> (default: info)', /^(fatal|error|warn|info|debug|trace)$/i, 'info')
   .option('-m, --log-mode <mode>', 'the console log mode <short,long,json,off> (default: short)', /^(short|long|json|off)$/i, 'short')
-  .option('-s, --skip <feature>', 'skip an export feature <fhir,json,all> (default: <none>)', collect, [])
+  .option('-s, --skip <feature>', 'skip an export feature <fhir,json,canjson,all> (default: <none>)', collect, [])
   .option('-o, --out <out>', 'the path to the output folder (default: ./out)', './out')
   .arguments('<path-to-shr-defs>')
   .action(function (pathToShrDefs) {
@@ -45,6 +45,7 @@ if (typeof input === 'undefined') {
 // Process the skip flags
 const doFHIR = program.skip.every(a => a.toLowerCase() != 'fhir' && a.toLowerCase() != 'all');
 const doJSON = program.skip.every(a => a.toLowerCase() != 'json' && a.toLowerCase() != 'all');
+const doCanJSON = program.skip.every(a => a.toLowerCase() != 'canjson' && a.toLowerCase() != 'all');
 
 // Create the output folder if necessary
 mkdirp.sync(program.out);
@@ -84,10 +85,8 @@ const configSpecifications = shrTI.importConfigFromFilePath(input);
 const specifications = shrTI.importFromFilePath(input, configSpecifications);
 const expSpecifications = shrEx.expand(specifications, shrFE);
 
-//canonicaljson() {
-var doCanonicalJson = true;
-
-if (doCanonicalJson) {
+//canonicaljson
+if (doCanJSON) {
   //data elements 
 
   for (const de of expSpecifications.dataElements.all) {

--- a/app.js
+++ b/app.js
@@ -84,9 +84,66 @@ const configSpecifications = shrTI.importConfigFromFilePath(input);
 const specifications = shrTI.importFromFilePath(input, configSpecifications);
 const expSpecifications = shrEx.expand(specifications, shrFE);
 
+//canonicaljson() {
+var doCanonicalJson = true;
+
+if (doCanonicalJson) {
+  //data elements 
+
+  for (const de of expSpecifications.dataElements.all) {
+    let namespace = de.identifier.namespace.replace(/\./, '-');
+    let fqn = de.identifier.fqn.replace(/\./g, '-');
+
+    const hierarchyPath = `${program.out}/canonicaljson/${namespace}/${fqn}.json`;
+    mkdirp.sync(hierarchyPath.substring(0, hierarchyPath.lastIndexOf('/')));
+    fs.writeFileSync(hierarchyPath, JSON.stringify(de, null, '  '));
+  }
+
+  //valuesets
+
+  for (const vs of expSpecifications.valueSets.all) {
+    let namespace = vs.identifier.namespace.replace(/\./, '-');
+    let name = vs.identifier.name.replace(/\./g, '-');;
+  
+    const hierarchyPath = `${program.out}/canonicaljson/${namespace}/valuesets/${name}.json`;
+    mkdirp.sync(hierarchyPath.substring(0, hierarchyPath.lastIndexOf('/')));
+    fs.writeFileSync(hierarchyPath, JSON.stringify(vs, null, '  '));
+  }
+
+  //mappings
+
+  for (const mapping of [...expSpecifications.maps._targetMap][0][1].all) {
+    let namespace = mapping.identifier.namespace.replace(/\./, '-');
+    let name = mapping.identifier.name;
+
+    const hierarchyPath = `${program.out}/canonicaljson/${namespace}/mappings/${name}-mapping.json`;
+    mkdirp.sync(hierarchyPath.substring(0, hierarchyPath.lastIndexOf('/')));
+    fs.writeFileSync(hierarchyPath, JSON.stringify(mapping, null, '  '));
+  }
+
+    //meta files
+    let versionInfo = {
+      "CAMEO_version": "5.2.1",
+      "Canonical_JSON_version": "0.9"
+    };
+  
+    let projectMetaOutput = Object.assign({}, configSpecifications, versionInfo); //project meta information
+    const hierarchyPath = `${program.out}/canonicaljson/project.json`;
+    mkdirp.sync(hierarchyPath.substring(0, hierarchyPath.lastIndexOf('/')));
+    fs.writeFileSync(hierarchyPath, JSON.stringify(projectMetaOutput, null, '  '));
+  
+    for (const ns of expSpecifications.namespaces.all) { //namespace files
+      let namespace = ns.namespace.replace(/\./, '-');
+  
+      const hierarchyPath = `${program.out}/canonicaljson/${namespace}/${namespace}.json`;
+      mkdirp.sync(hierarchyPath.substring(0, hierarchyPath.lastIndexOf('/')));
+      fs.writeFileSync(hierarchyPath, JSON.stringify(ns, null, '  '));
+    }  
+}
+  
 if (doJSON) {
   const jsonHierarchyResults = shrJE.exportToJSON(specifications, configSpecifications);
-  const hierarchyPath = `${program.out}/json/definitons.json`;
+  const hierarchyPath = `${program.out}/json/definitions.json`;
   mkdirp.sync(hierarchyPath.substring(0, hierarchyPath.lastIndexOf('/')));
   fs.writeFileSync(hierarchyPath, JSON.stringify(jsonHierarchyResults, null, '  '));
 } else {

--- a/app.js
+++ b/app.js
@@ -123,7 +123,7 @@ if (doCanJSON) {
     //meta files
     let versionInfo = {
       "CAMEO_version": "5.2.1",
-      "Canonical_JSON_version": "0.9"
+      "Canonical_JSON_version": "1.0"
     };
   
     let projectMetaOutput = Object.assign({}, configSpecifications, versionInfo); //project meta information

--- a/app.js
+++ b/app.js
@@ -136,7 +136,7 @@ if (doCIMCORE) {
 
   //meta project file
   let versionInfo = {
-    "CAMEO_version": "5.4.0",
+    "CIMPL_version": "5.4.0",
     "Canonical_JSON_version": "1.0"
   };
 

--- a/error_docs.md
+++ b/error_docs.md
@@ -100,6 +100,10 @@
 | 14001          | Unsupported value set rule type: `$s` |
 | 14002          | Unknown type for value `$VALUE` |
 | 14003          | Unknown type for constraint `$CONSTRAINT` |
+| 15001          | Unable to successfully serialize element `$ELEMENT` into CIMCORE, failing with error `$ERROR_MSG`. |
+| 15002          | Unable to successfully serialize value set `$VALUE_SET` into CIMCORE, failing with error `$ERROR_MSG`. |
+| 15003          | Unable to successfully serialize mapping `$MAPPING` into CIMCORE, failing with error `$ERROR_MSG`. |
+| 15004          | Unable to successfully serialize namespace meta data `$NAMESPACE` into CIMCORE, failing with error `$ERROR_MSG`. |
 
 ### Mapping Errors
 
@@ -160,7 +164,7 @@
 &nbsp;↳&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;First digit tells whether it is an warning or error. 0 = warning, 1 = error <br>
 
 1 ***2*** 3 4 5 <br>
-&nbsp;&nbsp;&nbsp;↳&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Second digit gives the location of the issue: 1 = the grammar and importing of the text files, 2 = the expanding of the specifications, 3 = the exporting of FHIR profiles, 4 = the exporting of the JSON profiles <br>
+&nbsp;&nbsp;&nbsp;↳&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Second digit gives the location of the issue: 1 = the grammar and importing of the text files, 2 = the expanding of the specifications, 3 = the exporting of FHIR profiles, 4 = the exporting of the JSON profiles, 5 = the exporting of CIMCORE files <br>
 
 1 2 ***3 4 5*** <br>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;↳&nbsp;&nbsp; The last two digits are simply for unique identification. <br>

--- a/error_docs.md
+++ b/error_docs.md
@@ -95,6 +95,8 @@
 | 12033          | Cannot map Value since element does not define a value             | Define a value for your element |
 | 12034          | Cannot map Value since it is unsupported type: `$VALUE_TYPE`       | ? |
 | 12035          | Found multiple matches for field `$FIELD`                          | Please use fully qualified identifier. |
+| 12036          | Could not find expanded definition of `$ELEMENT`. Inheritance calculations will be incomplete. | Double check `shr.base.Entry` is defined within the specifications. |
+| 12037          | Could not find based on element `$ELEMENT` for child element `$ELEMENT`. | Double check the `basedOn` element is defined within the specifications and correctly referenced. |
 | 14001          | Unsupported value set rule type: `$s` |
 | 14002          | Unknown type for value `$VALUE` |
 | 14003          | Unknown type for constraint `$CONSTRAINT` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-cli",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "description": "Command-line interface for SHR tools",
   "author": "",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
     "commander": "^2.9.0",
     "mkdirp": "^0.5.1",
     "shr-es6-export": "^5.2.0",
-    "shr-expand": "^5.2.7",
+    "shr-expand": "~5.3.0",
     "shr-fhir-export": "^5.3.7",
     "shr-json-export": "^5.1.3",
     "shr-json-schema-export": "^5.2.0",
-    "shr-models": "^5.2.2",
+    "shr-models": "~5.3.0",
     "shr-text-import": "^5.2.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-cli",
-  "version": "5.3.2",
+  "version": "5.4.0",
   "description": "Command-line interface for SHR tools",
   "author": "",
   "license": "Apache-2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -775,9 +775,9 @@ shr-es6-export@^5.2.0:
   dependencies:
     reserved-words "^0.1.2"
 
-shr-expand@^5.2.7:
-  version "5.2.7"
-  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.2.7.tgz#510cbf479d5f7920c9247b68b4915e288ea6d962"
+shr-expand@~5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.3.0.tgz#c19539d99b75c5986b62216b422618c3f6491391"
 
 shr-fhir-export@^5.3.7:
   version "5.3.7"
@@ -793,9 +793,9 @@ shr-json-schema-export@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/shr-json-schema-export/-/shr-json-schema-export-5.2.0.tgz#02910ee6c0de23e910b01047224edea441c9fc68"
 
-shr-models@^5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.2.2.tgz#42b9f13deded480628529e22bca09af546f8ba81"
+shr-models@~5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.3.0.tgz#e2416ca103e5ad9a434d85c20b40a7a516ce70e7"
 
 shr-text-import@^5.2.3:
   version "5.2.3"


### PR DESCRIPTION
Exports the canonical json forms of Data Elements, Mappings, Value Sets, and project meta files.

Toggle-able by the flag '-skip canjson' (work in progress name).

Outputs in ./out/canonicaljson

Needs to watch out for not clearing the out folder. Old element files can remain perpetually as nothing is overwritten, simply rewritten and created new if needed.