### PR TITLE
Added support for exporting JSON schema and ES6 classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $ node . --help
     -h, --help               output usage information
     -l, --log-level <level>  the console log level <fatal,error,warn,info,debug,trace> (default: info)
     -m, --log-mode <mode>    the console log mode <short,long,json,off> (default: short)
-    -s, --skip <feature>     skip an export feature <fhir,json,all> (default: <none>)
+    -s, --skip <feature>     skip an export feature <fhir,json,json-schema,all> (default: <none>)
     -o, --out <out>          the path to the output folder (default: ./out)
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $ node . --help
     -h, --help               output usage information
     -l, --log-level <level>  the console log level <fatal,error,warn,info,debug,trace> (default: info)
     -m, --log-mode <mode>    the console log mode <short,long,json,off> (default: short)
-    -s, --skip <feature>     skip an export feature <fhir,json,json-schema,all> (default: <none>)
+    -s, --skip <feature>     skip an export feature <fhir,json,json-schema,es6,all> (default: <none>)
     -o, --out <out>          the path to the output folder (default: ./out)
 ```
 

--- a/app.js
+++ b/app.js
@@ -15,7 +15,8 @@ const LogCounter = require('./logcounter');
 
 /* eslint-disable no-console */
 
-sanityCheckModules({shrTI, shrEx, shrJE, shrJSE, shrFE });
+// NOTE: shr-es6-export does not currently support the sanity check
+sanityCheckModules({shrTI, shrEx, shrJE, shrJSE, /*shrEE,*/ shrFE });
 
 // Record the time so we can print elapsed time
 const hrstart = process.hrtime();
@@ -30,7 +31,7 @@ program
   .usage('<path-to-shr-defs> [options]')
   .option('-l, --log-level <level>', 'the console log level <fatal,error,warn,info,debug,trace> (default: info)', /^(fatal|error|warn|info|debug|trace)$/i, 'info')
   .option('-m, --log-mode <mode>', 'the console log mode <short,long,json,off> (default: short)', /^(short|long|json|off)$/i, 'short')
-  .option('-s, --skip <feature>', 'skip an export feature <fhir,json,json-schema,all> (default: <none>)', collect, [])
+  .option('-s, --skip <feature>', 'skip an export feature <fhir,json,json-schema,es6,all> (default: <none>)', collect, [])
   .option('-o, --out <out>', 'the path to the output folder (default: ./out)', './out')
   .arguments('<path-to-shr-defs>')
   .action(function (pathToShrDefs) {
@@ -84,6 +85,7 @@ if (doFHIR) {
 if (doJSONSchema) {
   shrJSE.setLogger(logger.child({module: 'shr-json-schema-export'}));
 }
+// NOTE: shr-es6-export does not currently support a Bunyan logger
 
 // Go!
 logger.info('Starting CLI Import/Export');

--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ const shrTI = require('shr-text-import');
 const shrEx = require('shr-expand');
 const shrJE = require('shr-json-export');
 const shrJSE = require('shr-json-schema-export');
+const shrEE = require('shr-es6-export');
 const shrFE = require('shr-fhir-export');
 const LogCounter = require('./logcounter');
 
@@ -46,7 +47,8 @@ if (typeof input === 'undefined') {
 // Process the skip flags
 const doFHIR = program.skip.every(a => a.toLowerCase() != 'fhir' && a.toLowerCase() != 'all');
 const doJSON = program.skip.every(a => a.toLowerCase() != 'json' && a.toLowerCase() != 'all');
-const doJSONSchema = program.skip.every(a => a.toLowerCase() != 'json-shcema' && a.toLowerCase() != 'all');
+const doJSONSchema = program.skip.every(a => a.toLowerCase() != 'json-schema' && a.toLowerCase() != 'all');
+const doES6 = program.skip.every(a => a.toLowerCase() != 'es6' && a.toLowerCase() != 'all');
 
 // Create the output folder if necessary
 mkdirp.sync(program.out);
@@ -97,6 +99,25 @@ if (doJSON) {
 } else {
   logger.info('Skipping JSON export');
 }
+
+if (doES6) {
+  const es6Results = shrEE.exportToES6(expSpecifications, configSpecifications);
+  const es6Path = path.join(program.out, 'es6');
+  const handleNS = (obj, fpath) => {
+    mkdirp.sync(fpath);
+    for (const key of Object.keys(obj)) {
+      if (key.endsWith('.js')) {
+        fs.writeFileSync(path.join(fpath, key), obj[key]);
+      } else {
+        handleNS(obj[key], path.join(fpath, key));
+      }
+    }
+  };
+  handleNS(es6Results, es6Path);
+} else {
+  logger.info('Skipping ES6 export');
+}
+
 
 if (doFHIR) {
   const fhirResults = shrFE.exportToFHIR(expSpecifications, configSpecifications);

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "commander": "^2.9.0",
     "mkdirp": "^0.5.1",
     "shr-es6-export": "^5.2.0",
-    "shr-expand": "^5.2.6",
+    "shr-expand": "^5.2.7",
     "shr-fhir-export": "^5.3.7",
     "shr-json-export": "^5.1.3",
     "shr-json-schema-export": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "shr-expand": "^5.2.6",
     "shr-fhir-export": "^5.3.7",
     "shr-json-export": "^5.1.3",
+    "shr-json-schema-export": "^5.2.0",
     "shr-models": "^5.2.2",
     "shr-text-import": "^5.2.3"
   },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "bunyan": "^1.8.12",
     "commander": "^2.9.0",
     "mkdirp": "^0.5.1",
+    "shr-es6-export": "https://github.com/standardhealth/shr-es6-export",
     "shr-expand": "^5.2.6",
     "shr-fhir-export": "^5.3.7",
     "shr-json-export": "^5.1.3",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "bunyan": "^1.8.12",
     "commander": "^2.9.0",
     "mkdirp": "^0.5.1",
-    "shr-es6-export": "^5.2.0-alpha.2",
+    "shr-es6-export": "^5.2.0-alpha.3",
     "shr-expand": "^5.2.6",
     "shr-fhir-export": "^5.3.7",
     "shr-json-export": "^5.1.3",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "bunyan": "^1.8.12",
     "commander": "^2.9.0",
     "mkdirp": "^0.5.1",
-    "shr-es6-export": "^5.2.0-alpha.3",
+    "shr-es6-export": "^5.2.0",
     "shr-expand": "^5.2.6",
     "shr-fhir-export": "^5.3.7",
     "shr-json-export": "^5.1.3",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "bunyan": "^1.8.12",
     "commander": "^2.9.0",
     "mkdirp": "^0.5.1",
-    "shr-es6-export": "^5.2.0-alpha.1",
+    "shr-es6-export": "^5.2.0-alpha.2",
     "shr-expand": "^5.2.6",
     "shr-fhir-export": "^5.3.7",
     "shr-json-export": "^5.1.3",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "bunyan": "^1.8.12",
     "commander": "^2.9.0",
     "mkdirp": "^0.5.1",
-    "shr-es6-export": "https://github.com/standardhealth/shr-es6-export",
+    "shr-es6-export": "^5.2.0-alpha.1",
     "shr-expand": "^5.2.6",
     "shr-fhir-export": "^5.3.7",
     "shr-json-export": "^5.1.3",

--- a/rebuild-all
+++ b/rebuild-all
@@ -22,6 +22,10 @@ cd ../shr-json-export
 rm -rf node_modules
 yarn
 
+cd ../shr-json-schema-export
+rm -rf node_modules
+yarn
+
 cd ../shr-es6-export
 rm -rf node_modules
 yarn

--- a/rebuild-all
+++ b/rebuild-all
@@ -22,6 +22,10 @@ cd ../shr-json-export
 rm -rf node_modules
 yarn
 
+cd ../shr-es6-export
+rm -rf node_modules
+yarn
+
 cd ../shr-fhir-export
 rm -rf node_modules
 yarn

--- a/yarn-link-all
+++ b/yarn-link-all
@@ -22,6 +22,11 @@ yarn link shr-models
 yarn link shr-test-helpers
 yarn link
 
+cd ../shr-es6-export
+yarn link shr-models
+yarn link shr-test-helpers
+yarn link
+
 cd ../shr-fhir-export
 yarn link shr-models
 yarn link shr-test-helpers
@@ -32,4 +37,5 @@ yarn link shr-models
 yarn link shr-expand
 yarn link shr-text-import
 yarn link shr-json-export
+yarn link shr-es6-export
 yarn link shr-fhir-export

--- a/yarn-link-all
+++ b/yarn-link-all
@@ -22,8 +22,17 @@ yarn link shr-models
 yarn link shr-test-helpers
 yarn link
 
+cd ../shr-json-schema-export
+yarn link shr-models
+yarn link shr-expand
+yarn link shr-test-helpers
+yarn link
+
 cd ../shr-es6-export
 yarn link shr-models
+yarn link shr-text-import
+yarn link shr-expand
+yarn link shr-json-schema-export
 yarn link shr-test-helpers
 yarn link
 

--- a/yarn-unlink-all
+++ b/yarn-unlink-all
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
 
 yarn unlink shr-fhir-export
+yarn unlink shr-es6-export
 yarn unlink shr-json-export
 yarn unlink shr-text-import
 yarn unlink shr-expand
 yarn unlink shr-models
 
 cd ../shr-fhir-export
+yarn unlink shr-models
+yarn unlink shr-test-helpers
+yarn unlink
+
+cd ../shr-es6-export
 yarn unlink shr-models
 yarn unlink shr-test-helpers
 yarn unlink

--- a/yarn-unlink-all
+++ b/yarn-unlink-all
@@ -14,6 +14,15 @@ yarn unlink
 
 cd ../shr-es6-export
 yarn unlink shr-models
+yarn unlink shr-text-import
+yarn unlink shr-expand
+yarn unlink shr-json-schema-export
+yarn unlink shr-test-helpers
+yarn unlink
+
+cd ../shr-json-schema-export
+yarn unlink shr-models
+yarn unlink shr-expand
 yarn unlink shr-test-helpers
 yarn unlink
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -779,6 +779,10 @@ shr-json-export@^5.1.3:
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/shr-json-export/-/shr-json-export-5.1.3.tgz#ea99fd3bfeb47562f122488748c05f0e10fcb3a0"
 
+shr-json-schema-export@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/shr-json-schema-export/-/shr-json-schema-export-5.2.0.tgz#02910ee6c0de23e910b01047224edea441c9fc68"
+
 shr-models@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.2.2.tgz#42b9f13deded480628529e22bca09af546f8ba81"

--- a/yarn.lock
+++ b/yarn.lock
@@ -769,6 +769,12 @@ shr-expand@^5.2.6:
   version "5.2.6"
   resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.2.6.tgz#47b82c0eb31c974e9fcfcdfc6938952804ac3bdb"
 
+"shr-es6-export@https://github.com/standardhealth/shr-es6-export":
+  version "5.0.0"
+  resolved "https://github.com/standardhealth/shr-es6-export#65b388267ee9c2bd49ece74191eb8539badda012"
+  dependencies:
+    shr-models "^5.1.0"
+
 shr-fhir-export@^5.3.7:
   version "5.3.7"
   resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.3.7.tgz#72c33d48c7c8c056f5e50cc93f087c9e03b6ae2b"

--- a/yarn.lock
+++ b/yarn.lock
@@ -769,9 +769,9 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
-shr-es6-export@^5.2.0-alpha.3:
-  version "5.2.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/shr-es6-export/-/shr-es6-export-5.2.0-alpha.3.tgz#1d6c686500ed55c9a6c1c2d89fee160e32334b58"
+shr-es6-export@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/shr-es6-export/-/shr-es6-export-5.2.0.tgz#7a7df106545abbf889fc5cfa0e7143e72f2b83b0"
   dependencies:
     reserved-words "^0.1.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -765,15 +765,13 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
+shr-es6-export@^5.2.0-alpha.1:
+  version "5.2.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/shr-es6-export/-/shr-es6-export-5.2.0-alpha.1.tgz#bd4e71ef41fa3eb2a977cf2e8da180f322b85a13"
+
 shr-expand@^5.2.6:
   version "5.2.6"
   resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.2.6.tgz#47b82c0eb31c974e9fcfcdfc6938952804ac3bdb"
-
-"shr-es6-export@https://github.com/standardhealth/shr-es6-export":
-  version "5.0.0"
-  resolved "https://github.com/standardhealth/shr-es6-export#65b388267ee9c2bd49ece74191eb8539badda012"
-  dependencies:
-    shr-models "^5.1.0"
 
 shr-fhir-export@^5.3.7:
   version "5.3.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -775,9 +775,9 @@ shr-es6-export@^5.2.0:
   dependencies:
     reserved-words "^0.1.2"
 
-shr-expand@^5.2.6:
-  version "5.2.6"
-  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.2.6.tgz#47b82c0eb31c974e9fcfcdfc6938952804ac3bdb"
+shr-expand@^5.2.7:
+  version "5.2.7"
+  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.2.7.tgz#510cbf479d5f7920c9247b68b4915e288ea6d962"
 
 shr-fhir-export@^5.3.7:
   version "5.3.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -765,9 +765,9 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
-shr-es6-export@^5.2.0-alpha.1:
-  version "5.2.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/shr-es6-export/-/shr-es6-export-5.2.0-alpha.1.tgz#bd4e71ef41fa3eb2a977cf2e8da180f322b85a13"
+shr-es6-export@^5.2.0-alpha.2:
+  version "5.2.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/shr-es6-export/-/shr-es6-export-5.2.0-alpha.2.tgz#6377e3bf8849c388b18bd26c7c9ad24d734f0fa2"
 
 shr-expand@^5.2.6:
   version "5.2.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -704,6 +704,10 @@ require-uncached@^1.0.3:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
 
+reserved-words@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/reserved-words/-/reserved-words-0.1.2.tgz#00a0940f98cd501aeaaac316411d9adc52b31ab1"
+
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
@@ -765,9 +769,11 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
-shr-es6-export@^5.2.0-alpha.2:
-  version "5.2.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/shr-es6-export/-/shr-es6-export-5.2.0-alpha.2.tgz#6377e3bf8849c388b18bd26c7c9ad24d734f0fa2"
+shr-es6-export@^5.2.0-alpha.3:
+  version "5.2.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/shr-es6-export/-/shr-es6-export-5.2.0-alpha.3.tgz#1d6c686500ed55c9a6c1c2d89fee160e32334b58"
+  dependencies:
+    reserved-words "^0.1.2"
 
 shr-expand@^5.2.6:
   version "5.2.6"


### PR DESCRIPTION
SQUASHED and REBASED JSON-Schema code from John's json-schema-export branch.

I've confirmed that it produces the _same_ JSON schema files.

REBASED code from Chris's es6_export branch.

I've confirmed that it produces the _same_ ES6 files.