### PR TITLE
Support for special keywords (_Value, _Entry, _Concept)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ To run the SHR command-line interface, you need to first download the _shr-cli_ 
 
 To run the command-line interface, you must perform the following steps to install its dependencies:
 
-1. Install [Node.js](https://nodejs.org/en/download/)
-2. Install [Yarn](https://yarnpkg.com/en/docs/install)
+1. Install [Node.js](https://nodejs.org/en/download/) (LTS edition, currently 8.x)
+2. Install [Yarn](https://yarnpkg.com/en/docs/install) (1.3.x or above)
 3. Execute the following from this project's root directory: `yarn`
 
 # Exporting SHR to JSON and FHIR

--- a/app.js
+++ b/app.js
@@ -15,8 +15,7 @@ const LogCounter = require('./logcounter');
 
 /* eslint-disable no-console */
 
-// NOTE: shr-es6-export does not currently support the sanity check
-sanityCheckModules({shrTI, shrEx, shrJE, shrJSE, /*shrEE,*/ shrFE });
+sanityCheckModules({shrTI, shrEx, shrJE, shrJSE, shrEE, shrFE });
 
 // Record the time so we can print elapsed time
 const hrstart = process.hrtime();

--- a/error_docs.md
+++ b/error_docs.md
@@ -167,6 +167,7 @@
 | 13058          | Cannot fix `$TARGET` to `$VALUE` since it is not a `$TYPE` type. |
 | 13059          | Cannot fix `$TARGET` to `$VALUE` since it is already fixed to `$OTHER_VALUE`. |
 | 13060          | Could not determine how to map nested value (`$ELEMENT_PATH`) to FHIR profile. |
+| 13061          | Mapping _Concept sub-fields is currently not supported. |
 
 # Code Number Explanation
 

--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
     "bunyan": "^1.8.12",
     "commander": "^2.9.0",
     "mkdirp": "^0.5.1",
-    "shr-es6-export": "^5.2.1",
-    "shr-expand": "standardhealth/shr-expand#underscore_kw",
-    "shr-fhir-export": "standardhealth/shr-fhir-export#underscore_kw",
+    "shr-es6-export": "^5.3.0",
+    "shr-expand": "^5.4.0",
+    "shr-fhir-export": "^5.4.0",
     "shr-json-export": "^5.1.4",
     "shr-json-schema-export": "^5.2.1",
-    "shr-models": "standardhealth/shr-models#underscore_kw",
-    "shr-text-import": "standardhealth/shr-text-import#underscore_kw"
+    "shr-models": "^5.4.0",
+    "shr-text-import": "^5.3.0"
   },
   "devDependencies": {
     "eslint": "^4.6.1"

--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
     "commander": "^2.9.0",
     "mkdirp": "^0.5.1",
     "shr-es6-export": "^5.2.1",
-    "shr-expand": "~5.3.0",
-    "shr-fhir-export": "^5.3.8",
+    "shr-expand": "standardhealth/shr-expand#underscore_kw",
+    "shr-fhir-export": "standardhealth/shr-fhir-export#underscore_kw",
     "shr-json-export": "^5.1.4",
     "shr-json-schema-export": "^5.2.1",
-    "shr-models": "~5.3.0",
-    "shr-text-import": "^5.2.3"
+    "shr-models": "standardhealth/shr-models#underscore_kw",
+    "shr-text-import": "standardhealth/shr-text-import#underscore_kw"
   },
   "devDependencies": {
     "eslint": "^4.6.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-cli",
-  "version": "5.5.1",
+  "version": "5.6.0",
   "description": "Command-line interface for SHR tools",
   "author": "",
   "license": "Apache-2.0",

--- a/pull-all
+++ b/pull-all
@@ -1,60 +1,41 @@
 #!/usr/bin/env bash
 
+cd ../shr_spec
+echo "===================== shr_spec ====================="
+git pull
+
 cd ../shr-models
 echo "==================== shr-models ===================="
-yarn link
+git pull
 
 cd ../shr-test-helpers
 echo "================= shr-test-helpers ================="
-yarn link shr-models
-yarn link
+git pull
 
 cd ../shr-expand
 echo "==================== shr-expand ===================="
-yarn link shr-models
-yarn link shr-test-helpers
-yarn link
+git pull
 
 cd ../shr-text-import
 echo "================= shr-text-import =================="
-yarn link shr-models
-yarn link shr-test-helpers
-yarn link
+git pull
 
 cd ../shr-json-export
 echo "================= shr-json-export =================="
-yarn link shr-models
-yarn link shr-test-helpers
-yarn link
+git pull
 
 cd ../shr-json-schema-export
 echo "============== shr-json-schema-export =============="
-yarn link shr-models
-yarn link shr-expand
-yarn link shr-test-helpers
-yarn link
+git pull
 
 cd ../shr-es6-export
 echo "================== shr-es6-export =================="
-yarn link shr-models
-yarn link shr-text-import
-yarn link shr-expand
-yarn link shr-json-schema-export
-yarn link shr-test-helpers
-yarn link
+git pull
 
 cd ../shr-fhir-export
 echo "================= shr-fhir-export =================="
-yarn link shr-models
-yarn link shr-test-helpers
-yarn link
+git pull
 
 cd ../shr-cli
 echo "===================== shr-cli ======================"
-yarn link shr-models
-yarn link shr-expand
-yarn link shr-text-import
-yarn link shr-json-export
-yarn link shr-json-schema-export
-yarn link shr-es6-export
-yarn link shr-fhir-export
+git pull

--- a/rebuild-all
+++ b/rebuild-all
@@ -1,39 +1,46 @@
 #!/usr/bin/env bash
 
-yarn cache clean
-
 cd ../shr-models
+echo "==================== shr-models ===================="
 rm -rf node_modules
 yarn
 
 cd ../shr-test-helpers
+echo "================= shr-test-helpers ================="
 rm -rf node_modules
 yarn
 
 cd ../shr-expand
+echo "==================== shr-expand ===================="
 rm -rf node_modules
 yarn
 
 cd ../shr-text-import
+echo "================= shr-text-import =================="
 rm -rf node_modules
 yarn
 
 cd ../shr-json-export
+echo "================= shr-json-export =================="
 rm -rf node_modules
 yarn
 
 cd ../shr-json-schema-export
+echo "============== shr-json-schema-export =============="
 rm -rf node_modules
 yarn
 
 cd ../shr-es6-export
+echo "================== shr-es6-export =================="
 rm -rf node_modules
 yarn
 
 cd ../shr-fhir-export
+echo "================= shr-fhir-export =================="
 rm -rf node_modules
 yarn
 
 cd ../shr-cli
+echo "===================== shr-cli ======================"
 rm -rf node_modules
 yarn

--- a/yarn-unlink-all
+++ b/yarn-unlink-all
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+echo "===================== shr-cli ======================"
 yarn unlink shr-fhir-export
 yarn unlink shr-es6-export
 yarn unlink shr-json-schema-export
@@ -9,11 +10,13 @@ yarn unlink shr-expand
 yarn unlink shr-models
 
 cd ../shr-fhir-export
+echo "================= shr-fhir-export =================="
 yarn unlink shr-models
 yarn unlink shr-test-helpers
 yarn unlink
 
 cd ../shr-es6-export
+echo "================== shr-es6-export =================="
 yarn unlink shr-models
 yarn unlink shr-text-import
 yarn unlink shr-expand
@@ -22,31 +25,37 @@ yarn unlink shr-test-helpers
 yarn unlink
 
 cd ../shr-json-schema-export
+echo "============== shr-json-schema-export =============="
 yarn unlink shr-models
 yarn unlink shr-expand
 yarn unlink shr-test-helpers
 yarn unlink
 
 cd ../shr-json-export
+echo "================= shr-json-export =================="
 yarn unlink shr-models
 yarn unlink shr-test-helpers
 yarn unlink
 
 cd ../shr-text-import
+echo "================= shr-text-import =================="
 yarn unlink shr-models
 yarn unlink shr-test-helpers
 yarn unlink
 
 cd ../shr-expand
+echo "==================== shr-expand ===================="
 yarn unlink shr-models
 yarn unlink shr-test-helpers
 yarn unlink
 
 cd ../shr-test-helpers
+echo "================= shr-test-helpers ================="
 yarn unlink shr-models
 yarn unlink
 
 cd ../shr-models
+echo "==================== shr-models ===================="
 yarn unlink
 
 cd ../shr-cli

--- a/yarn.lock
+++ b/yarn.lock
@@ -769,19 +769,19 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
-shr-es6-export@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/shr-es6-export/-/shr-es6-export-5.2.1.tgz#0dfc33392a7ae3a161f8b257b6c043dafa8af803"
+shr-es6-export@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/shr-es6-export/-/shr-es6-export-5.3.0.tgz#a7624216e42b7407a2e5f7270c74754980a71c63"
   dependencies:
     reserved-words "^0.1.2"
 
-shr-expand@standardhealth/shr-expand#underscore_kw:
-  version "5.3.0"
-  resolved "https://codeload.github.com/standardhealth/shr-expand/tar.gz/6c811e98979a0e7484a13799034e80baae3572a5"
+shr-expand@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.4.0.tgz#0e71525b2ffc4cf63268c910da257042e49f14d5"
 
-shr-fhir-export@standardhealth/shr-fhir-export#underscore_kw:
-  version "5.3.8"
-  resolved "https://codeload.github.com/standardhealth/shr-fhir-export/tar.gz/39280e3aa252fa4c986f6fc9e1f28aa077215531"
+shr-fhir-export@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.4.0.tgz#3e91942b90ea884b700a677d6f34b3938d4ab431"
   dependencies:
     fs-extra "^2.0.0"
 
@@ -793,13 +793,13 @@ shr-json-schema-export@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/shr-json-schema-export/-/shr-json-schema-export-5.2.1.tgz#2022a19b1e0f9ccb0c06b69e8e056bfc350e6f3a"
 
-shr-models@standardhealth/shr-models#underscore_kw:
-  version "5.3.0"
-  resolved "https://codeload.github.com/standardhealth/shr-models/tar.gz/bc825be96868efef1c30daa3cb7f8df163185be4"
+shr-models@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.4.0.tgz#6fc2542dbdb900a7e0a7d172962ce540deda190a"
 
-shr-text-import@standardhealth/shr-text-import#underscore_kw:
-  version "5.2.4"
-  resolved "https://codeload.github.com/standardhealth/shr-text-import/tar.gz/249639d8f333a9d11e0b771a6c02879917a6fcac"
+shr-text-import@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/shr-text-import/-/shr-text-import-5.3.0.tgz#30b03ad00c68fbc5404111b5af3bcd99cb49b06e"
   dependencies:
     antlr4 "~4.6.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -775,13 +775,13 @@ shr-es6-export@^5.2.1:
   dependencies:
     reserved-words "^0.1.2"
 
-shr-expand@~5.3.0:
+shr-expand@standardhealth/shr-expand#underscore_kw:
   version "5.3.0"
-  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.3.0.tgz#c19539d99b75c5986b62216b422618c3f6491391"
+  resolved "https://codeload.github.com/standardhealth/shr-expand/tar.gz/6c811e98979a0e7484a13799034e80baae3572a5"
 
-shr-fhir-export@^5.3.8:
+shr-fhir-export@standardhealth/shr-fhir-export#underscore_kw:
   version "5.3.8"
-  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.3.8.tgz#b699176a3c6c2e482580304ba7ecbc39029520b4"
+  resolved "https://codeload.github.com/standardhealth/shr-fhir-export/tar.gz/39280e3aa252fa4c986f6fc9e1f28aa077215531"
   dependencies:
     fs-extra "^2.0.0"
 
@@ -793,13 +793,13 @@ shr-json-schema-export@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/shr-json-schema-export/-/shr-json-schema-export-5.2.1.tgz#2022a19b1e0f9ccb0c06b69e8e056bfc350e6f3a"
 
-shr-models@~5.3.0:
+shr-models@standardhealth/shr-models#underscore_kw:
   version "5.3.0"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.3.0.tgz#e2416ca103e5ad9a434d85c20b40a7a516ce70e7"
+  resolved "https://codeload.github.com/standardhealth/shr-models/tar.gz/bc825be96868efef1c30daa3cb7f8df163185be4"
 
-shr-text-import@^5.2.3:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/shr-text-import/-/shr-text-import-5.2.3.tgz#0af683af80e1580fc84226b1a9376f075da6dfc3"
+shr-text-import@standardhealth/shr-text-import#underscore_kw:
+  version "5.2.4"
+  resolved "https://codeload.github.com/standardhealth/shr-text-import/tar.gz/249639d8f333a9d11e0b771a6c02879917a6fcac"
   dependencies:
     antlr4 "~4.6.0"
 


### PR DESCRIPTION
Brings in the libraries that add support for the new special words allowed by the grammar: `_Value`, `_Entry`, `_Concept`.  The main new feature here is support for mapping `_Concept`.

The easiest way to test this against the SHR is by editing `shr_spec/spec/shr_finding_map.txt`:
* Change `Entry.CreationTime maps to issued` to `_Entry.CreationTime maps to issued`
* Change `Value maps to value[x]` to `_Value maps to value[x]`
* Change `ObservationCode maps to code` to `_Concept maps to code`

NOTE:
* Once shr-* dependency PRs are approved and released, this will be updated to use them
* Version number will be bumped after final approval of the PR