### PR TITLE
Logical models

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,12 @@ Next, create the IG using the HL7 IG Publisher Tool.
 
 On Mac or Linux:
 ```
-$ java $JAVA_OPTS -Xms4g -Xmx8g -jar out/fhir/guide/org.hl7.fhir.igpublisher.jar -ig out/fhir/guide/data.json
+$ java $JAVA_OPTS -Xms4g -Xmx8g -jar out/fhir/guide/org.hl7.fhir.igpublisher.jar -ig out/fhir/guide/ig.json
 ```
 
 On Windows:
 ```
-> java %JAVA_OPTS% -Xms4g -Xmx8g -jar out/fhir/guide/org.hl7.fhir.igpublisher.jar -ig out/fhir/guide/data.json
+> java %JAVA_OPTS% -Xms4g -Xmx8g -jar out/fhir/guide/org.hl7.fhir.igpublisher.jar -ig out/fhir/guide/ig.json
 ```
 
 # License

--- a/app.js
+++ b/app.js
@@ -244,7 +244,7 @@ if (doFHIR) {
     fs.writeFileSync(path.join(baseFHIRModelsPath, `${model.id}.json`), JSON.stringify(model, null, 2));
   }
   fs.writeFileSync(path.join(baseFHIRPath, `shr_qa.html`), fhirResults.qaHTML);
-  shrFE.exportIG(fhirResults, path.join(baseFHIRPath, 'guide'), configSpecifications, input);
+  shrFE.exportIG(expSpecifications, fhirResults, path.join(baseFHIRPath, 'guide'), configSpecifications, input);
 } else {
   logger.info('Skipping FHIR export');
 }

--- a/app.js
+++ b/app.js
@@ -238,6 +238,11 @@ if (doFHIR) {
   for (const valueSet of fhirResults.valueSets) {
     fs.writeFileSync(path.join(baseFHIRValueSetsPath, `${valueSet.id}.json`), JSON.stringify(valueSet, null, 2));
   }
+  const baseFHIRModelsPath = path.join(baseFHIRPath, 'logical');
+  mkdirp.sync(baseFHIRModelsPath);
+  for (const model of fhirResults.models) {
+    fs.writeFileSync(path.join(baseFHIRModelsPath, `${model.id}.json`), JSON.stringify(model, null, 2));
+  }
   fs.writeFileSync(path.join(baseFHIRPath, `shr_qa.html`), fhirResults.qaHTML);
   shrFE.exportIG(fhirResults, path.join(baseFHIRPath, 'guide'), configSpecifications, input);
 } else {

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "bunyan": "^1.8.12",
     "commander": "^2.9.0",
     "mkdirp": "^0.5.1",
-    "shr-es6-export": "^5.3.0",
+    "shr-es6-export": "^5.3.1",
     "shr-expand": "standardhealth/shr-expand#logical_models",
     "shr-fhir-export": "standardhealth/shr-fhir-export#logical_models",
     "shr-json-export": "^5.1.4",
-    "shr-json-javadoc": "^1.3.0",
+    "shr-json-javadoc": "^1.3.2",
     "shr-json-schema-export": "standardhealth/shr-json-schema-export#logical_models",
     "shr-models": "standardhealth/shr-models#logical_models",
     "shr-text-import": "standardhealth/shr-text-import#logical_models"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "main": "app.js",
   "scripts": {
     "ig:publish": "java -Xms4g -Xmx8g -jar ./out/fhir/guide/org.hl7.fhir.igpublisher.jar -ig ./out/fhir/guide/ig.json",
+    "ig:open": "opener ./out/fhir/guide/output/index.html",
     "lint": "./node_modules/.bin/eslint .",
     "lint:fix": "./node_modules/.bin/eslint . --fix"
   },
@@ -23,12 +24,13 @@
     "shr-expand": "standardhealth/shr-expand#logical_models",
     "shr-fhir-export": "standardhealth/shr-fhir-export#logical_models",
     "shr-json-export": "^5.1.4",
-    "shr-json-schema-export": "^5.2.1",
     "shr-json-javadoc": "^1.2.2",
+    "shr-json-schema-export": "^5.2.1",
     "shr-models": "standardhealth/shr-models#logical_models",
     "shr-text-import": "standardhealth/shr-text-import#logical_models"
   },
   "devDependencies": {
-    "eslint": "^4.6.1"
+    "eslint": "^4.6.1",
+    "opener": "^1.4.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "shr-fhir-export": "standardhealth/shr-fhir-export#logical_models",
     "shr-json-export": "^5.1.4",
     "shr-json-javadoc": "^1.2.3",
-    "shr-json-schema-export": "^5.2.1",
+    "shr-json-schema-export": "standardhealth/shr-json-schema-export#logical_models",
     "shr-models": "standardhealth/shr-models#logical_models",
     "shr-text-import": "standardhealth/shr-text-import#logical_models"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "main": "app.js",
   "scripts": {
-    "ig:publish": "java -Xms4g -Xmx8g -jar ./out/fhir/guide/org.hl7.fhir.igpublisher.jar -ig ./out/fhir/guide/data.json",
+    "ig:publish": "java -Xms4g -Xmx8g -jar ./out/fhir/guide/org.hl7.fhir.igpublisher.jar -ig ./out/fhir/guide/ig.json",
     "lint": "./node_modules/.bin/eslint .",
     "lint:fix": "./node_modules/.bin/eslint . --fix"
   },

--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
     "mkdirp": "^0.5.1",
     "shr-es6-export": "^5.3.0",
     "shr-expand": "^5.4.0",
-    "shr-fhir-export": "^5.4.0",
+    "shr-fhir-export": "standardhealth/shr-fhir-export#logical_models",
     "shr-json-export": "^5.1.4",
     "shr-json-schema-export": "^5.2.1",
     "shr-json-javadoc": "^1.2.2",
-    "shr-models": "^5.4.0",
-    "shr-text-import": "^5.3.0"
+    "shr-models": "standardhealth/shr-models#logical_models",
+    "shr-text-import": "standardhealth/shr-text-import#logical_models"
   },
   "devDependencies": {
     "eslint": "^4.6.1"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "commander": "^2.9.0",
     "mkdirp": "^0.5.1",
     "shr-es6-export": "^5.3.0",
-    "shr-expand": "^5.4.0",
+    "shr-expand": "standardhealth/shr-expand#logical_models",
     "shr-fhir-export": "standardhealth/shr-fhir-export#logical_models",
     "shr-json-export": "^5.1.4",
     "shr-json-schema-export": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "ig:publish": "java -Xms4g -Xmx8g -jar ./out/fhir/guide/org.hl7.fhir.igpublisher.jar -ig ./out/fhir/guide/ig.json",
     "ig:open": "opener ./out/fhir/guide/output/index.html",
+    "ig:qa": "opener ./out/fhir/guide/output/qa.html",
     "lint": "./node_modules/.bin/eslint .",
     "lint:fix": "./node_modules/.bin/eslint . --fix"
   },
@@ -24,7 +25,7 @@
     "shr-expand": "standardhealth/shr-expand#logical_models",
     "shr-fhir-export": "standardhealth/shr-fhir-export#logical_models",
     "shr-json-export": "^5.1.4",
-    "shr-json-javadoc": "^1.2.3",
+    "shr-json-javadoc": "^1.3.0",
     "shr-json-schema-export": "standardhealth/shr-json-schema-export#logical_models",
     "shr-models": "standardhealth/shr-models#logical_models",
     "shr-text-import": "standardhealth/shr-text-import#logical_models"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "shr-expand": "standardhealth/shr-expand#logical_models",
     "shr-fhir-export": "standardhealth/shr-fhir-export#logical_models",
     "shr-json-export": "^5.1.4",
-    "shr-json-javadoc": "^1.3.2",
+    "shr-json-javadoc": "^1.3.3",
     "shr-json-schema-export": "standardhealth/shr-json-schema-export#logical_models",
     "shr-models": "standardhealth/shr-models#logical_models",
     "shr-text-import": "standardhealth/shr-text-import#logical_models"

--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
     "commander": "^2.9.0",
     "mkdirp": "^0.5.1",
     "shr-es6-export": "^5.3.1",
-    "shr-expand": "standardhealth/shr-expand#logical_models",
-    "shr-fhir-export": "standardhealth/shr-fhir-export#logical_models",
+    "shr-expand": "^5.5.0",
+    "shr-fhir-export": "^5.5.0",
     "shr-json-export": "^5.1.4",
     "shr-json-javadoc": "^1.3.3",
-    "shr-json-schema-export": "standardhealth/shr-json-schema-export#logical_models",
-    "shr-models": "standardhealth/shr-models#logical_models",
-    "shr-text-import": "standardhealth/shr-text-import#logical_models"
+    "shr-json-schema-export": "^5.2.2",
+    "shr-models": "^5.5.0",
+    "shr-text-import": "^5.3.1"
   },
   "devDependencies": {
     "eslint": "^4.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -776,13 +776,13 @@ shr-es6-export@^5.3.0:
   dependencies:
     reserved-words "^0.1.2"
 
-shr-expand@^5.4.0:
+shr-expand@standardhealth/shr-expand#logical_models:
   version "5.4.0"
-  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.4.0.tgz#0e71525b2ffc4cf63268c910da257042e49f14d5"
+  resolved "https://codeload.github.com/standardhealth/shr-expand/tar.gz/dcc0ec89de48eff6ad5c40c128e1ba90457ef03d"
 
 shr-fhir-export@standardhealth/shr-fhir-export#logical_models:
   version "5.4.0"
-  resolved "https://codeload.github.com/standardhealth/shr-fhir-export/tar.gz/ce092cb9c00bb15c14636e4cf506c3a2e56c1f1f"
+  resolved "https://codeload.github.com/standardhealth/shr-fhir-export/tar.gz/e52ca2ade3f1549361e9d090786d2139d801cb3f"
   dependencies:
     fs-extra "^2.0.0"
     lodash "^4.17.5"
@@ -805,7 +805,7 @@ shr-json-schema-export@^5.2.1:
 
 shr-models@standardhealth/shr-models#logical_models:
   version "5.4.0"
-  resolved "https://codeload.github.com/standardhealth/shr-models/tar.gz/cd3b0ad011d212f8fd15d67be12dc35335d033ff"
+  resolved "https://codeload.github.com/standardhealth/shr-models/tar.gz/c90fd75bc776088b5bf59a63e3d7e38e78d9435d"
 
 shr-text-import@standardhealth/shr-text-import#logical_models:
   version "5.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -776,13 +776,13 @@ shr-es6-export@^5.3.1:
   dependencies:
     reserved-words "^0.1.2"
 
-shr-expand@standardhealth/shr-expand#logical_models:
-  version "5.4.0"
-  resolved "https://codeload.github.com/standardhealth/shr-expand/tar.gz/1afc31c655ab7676ad6964f82163af5cfd3cc232"
+shr-expand@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.5.0.tgz#add3fd793d97350bdb9ae8f1ff195ab41226a9e2"
 
-shr-fhir-export@standardhealth/shr-fhir-export#logical_models:
-  version "5.4.0"
-  resolved "https://codeload.github.com/standardhealth/shr-fhir-export/tar.gz/4cf0531d8931f587b40517fc632743672a7443e8"
+shr-fhir-export@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.5.0.tgz#5d34154fefd7e76fb8bafe1024df1f0220a14889"
   dependencies:
     fs-extra "^2.0.0"
     lodash "^4.17.5"
@@ -799,17 +799,17 @@ shr-json-javadoc@^1.3.3:
     ejs "^2.5.7"
     ncp "^2.0.0"
 
-shr-json-schema-export@standardhealth/shr-json-schema-export#logical_models:
-  version "5.2.1"
-  resolved "https://codeload.github.com/standardhealth/shr-json-schema-export/tar.gz/b21ef8b56908f06ca9048a8f2d2cb0e1fda44403"
+shr-json-schema-export@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/shr-json-schema-export/-/shr-json-schema-export-5.2.2.tgz#20141775d14ff717bbfe220b05fe4cd2135ecfbc"
 
-shr-models@standardhealth/shr-models#logical_models:
-  version "5.4.0"
-  resolved "https://codeload.github.com/standardhealth/shr-models/tar.gz/c90fd75bc776088b5bf59a63e3d7e38e78d9435d"
+shr-models@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.5.0.tgz#41c163bfb22aa39678c2bafebccccb50a8574a3a"
 
-shr-text-import@standardhealth/shr-text-import#logical_models:
-  version "5.3.0"
-  resolved "https://codeload.github.com/standardhealth/shr-text-import/tar.gz/2102af271fadd46cedf8af4652f7858a08062e1b"
+shr-text-import@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/shr-text-import/-/shr-text-import-5.3.1.tgz#e17ed61830cbeb675692b1ae1c79501f1117f0ff"
   dependencies:
     antlr4 "~4.6.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -782,7 +782,7 @@ shr-expand@^5.4.0:
 
 shr-fhir-export@standardhealth/shr-fhir-export#logical_models:
   version "5.4.0"
-  resolved "https://codeload.github.com/standardhealth/shr-fhir-export/tar.gz/22d1cc3b541b4357196f6bdc7c096bd8f405c341"
+  resolved "https://codeload.github.com/standardhealth/shr-fhir-export/tar.gz/ce092cb9c00bb15c14636e4cf506c3a2e56c1f1f"
   dependencies:
     fs-extra "^2.0.0"
     lodash "^4.17.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -778,11 +778,11 @@ shr-es6-export@^5.3.0:
 
 shr-expand@standardhealth/shr-expand#logical_models:
   version "5.4.0"
-  resolved "https://codeload.github.com/standardhealth/shr-expand/tar.gz/dcc0ec89de48eff6ad5c40c128e1ba90457ef03d"
+  resolved "https://codeload.github.com/standardhealth/shr-expand/tar.gz/c3b50e7bea539124189d2898cd6109aaabaa0d48"
 
 shr-fhir-export@standardhealth/shr-fhir-export#logical_models:
   version "5.4.0"
-  resolved "https://codeload.github.com/standardhealth/shr-fhir-export/tar.gz/a50c33bbcd4d4bc3eea210dc0c9d6d1c37ef0c65"
+  resolved "https://codeload.github.com/standardhealth/shr-fhir-export/tar.gz/fd70a81b48380b1dadca7426afbe63988a26dcca"
   dependencies:
     fs-extra "^2.0.0"
     lodash "^4.17.5"
@@ -799,9 +799,9 @@ shr-json-javadoc@^1.2.3:
     ejs "^2.5.7"
     ncp "^2.0.0"
 
-shr-json-schema-export@^5.2.1:
+shr-json-schema-export@standardhealth/shr-json-schema-export#logical_models:
   version "5.2.1"
-  resolved "https://registry.yarnpkg.com/shr-json-schema-export/-/shr-json-schema-export-5.2.1.tgz#2022a19b1e0f9ccb0c06b69e8e056bfc350e6f3a"
+  resolved "https://codeload.github.com/standardhealth/shr-json-schema-export/tar.gz/b21ef8b56908f06ca9048a8f2d2cb0e1fda44403"
 
 shr-models@standardhealth/shr-models#logical_models:
   version "5.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -778,7 +778,7 @@ shr-es6-export@^5.3.0:
 
 shr-expand@standardhealth/shr-expand#logical_models:
   version "5.4.0"
-  resolved "https://codeload.github.com/standardhealth/shr-expand/tar.gz/c3b50e7bea539124189d2898cd6109aaabaa0d48"
+  resolved "https://codeload.github.com/standardhealth/shr-expand/tar.gz/1afc31c655ab7676ad6964f82163af5cfd3cc232"
 
 shr-fhir-export@standardhealth/shr-fhir-export#logical_models:
   version "5.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -239,8 +239,8 @@ dtrace-provider@~0.8:
     nan "^2.3.3"
 
 ejs@^2.5.7:
-  version "2.5.7"
-  resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.7.tgz#cc872c168880ae3c7189762fd5ffc00896c9518a"
+  version "2.5.8"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.8.tgz#2ab6954619f225e6193b7ac5f7c39c48fefe4380"
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -770,9 +770,9 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
-shr-es6-export@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/shr-es6-export/-/shr-es6-export-5.3.0.tgz#a7624216e42b7407a2e5f7270c74754980a71c63"
+shr-es6-export@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/shr-es6-export/-/shr-es6-export-5.3.1.tgz#292f23e957c55f1d870df94b87201b6876ec6e44"
   dependencies:
     reserved-words "^0.1.2"
 
@@ -782,7 +782,7 @@ shr-expand@standardhealth/shr-expand#logical_models:
 
 shr-fhir-export@standardhealth/shr-fhir-export#logical_models:
   version "5.4.0"
-  resolved "https://codeload.github.com/standardhealth/shr-fhir-export/tar.gz/6cbd0a482fae8d741a5f460078ba5081ebede900"
+  resolved "https://codeload.github.com/standardhealth/shr-fhir-export/tar.gz/5ea8396e59a31354707254880ed180b3bfacf688"
   dependencies:
     fs-extra "^2.0.0"
     lodash "^4.17.5"
@@ -791,9 +791,9 @@ shr-json-export@^5.1.4:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/shr-json-export/-/shr-json-export-5.1.4.tgz#9b1cc379002366db70ef529a39b8220253a860ee"
 
-shr-json-javadoc@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/shr-json-javadoc/-/shr-json-javadoc-1.3.0.tgz#d7cc4901c4c43f1215c23fa42f241d34b220b0cc"
+shr-json-javadoc@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/shr-json-javadoc/-/shr-json-javadoc-1.3.2.tgz#8b19511b52027a528f9ea99005df0174cadbc12d"
   dependencies:
     bluebird "^3.5.1"
     ejs "^2.5.7"
@@ -809,7 +809,7 @@ shr-models@standardhealth/shr-models#logical_models:
 
 shr-text-import@standardhealth/shr-text-import#logical_models:
   version "5.3.0"
-  resolved "https://codeload.github.com/standardhealth/shr-text-import/tar.gz/3d22434daf6875d15a6563b1cbe04de14c42cea0"
+  resolved "https://codeload.github.com/standardhealth/shr-text-import/tar.gz/2102af271fadd46cedf8af4652f7858a08062e1b"
   dependencies:
     antlr4 "~4.6.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -782,7 +782,7 @@ shr-expand@standardhealth/shr-expand#logical_models:
 
 shr-fhir-export@standardhealth/shr-fhir-export#logical_models:
   version "5.4.0"
-  resolved "https://codeload.github.com/standardhealth/shr-fhir-export/tar.gz/fd70a81b48380b1dadca7426afbe63988a26dcca"
+  resolved "https://codeload.github.com/standardhealth/shr-fhir-export/tar.gz/6cbd0a482fae8d741a5f460078ba5081ebede900"
   dependencies:
     fs-extra "^2.0.0"
     lodash "^4.17.5"
@@ -791,9 +791,9 @@ shr-json-export@^5.1.4:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/shr-json-export/-/shr-json-export-5.1.4.tgz#9b1cc379002366db70ef529a39b8220253a860ee"
 
-shr-json-javadoc@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/shr-json-javadoc/-/shr-json-javadoc-1.2.3.tgz#b1cbfb5bb3c49c823a0a9f99812fc5b40feba39c"
+shr-json-javadoc@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/shr-json-javadoc/-/shr-json-javadoc-1.3.0.tgz#d7cc4901c4c43f1215c23fa42f241d34b220b0cc"
   dependencies:
     bluebird "^3.5.1"
     ejs "^2.5.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -782,7 +782,7 @@ shr-expand@standardhealth/shr-expand#logical_models:
 
 shr-fhir-export@standardhealth/shr-fhir-export#logical_models:
   version "5.4.0"
-  resolved "https://codeload.github.com/standardhealth/shr-fhir-export/tar.gz/fbb9df698f454c3e2ef97c2aa581a9fb8e39688a"
+  resolved "https://codeload.github.com/standardhealth/shr-fhir-export/tar.gz/a50c33bbcd4d4bc3eea210dc0c9d6d1c37ef0c65"
   dependencies:
     fs-extra "^2.0.0"
     lodash "^4.17.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -791,9 +791,9 @@ shr-json-export@^5.1.4:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/shr-json-export/-/shr-json-export-5.1.4.tgz#9b1cc379002366db70ef529a39b8220253a860ee"
 
-shr-json-javadoc@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/shr-json-javadoc/-/shr-json-javadoc-1.3.2.tgz#8b19511b52027a528f9ea99005df0174cadbc12d"
+shr-json-javadoc@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/shr-json-javadoc/-/shr-json-javadoc-1.3.3.tgz#7c1485c65be85cf46f100dfe43fccdecf5ac16bd"
   dependencies:
     bluebird "^3.5.1"
     ejs "^2.5.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -782,7 +782,7 @@ shr-expand@standardhealth/shr-expand#logical_models:
 
 shr-fhir-export@standardhealth/shr-fhir-export#logical_models:
   version "5.4.0"
-  resolved "https://codeload.github.com/standardhealth/shr-fhir-export/tar.gz/e52ca2ade3f1549361e9d090786d2139d801cb3f"
+  resolved "https://codeload.github.com/standardhealth/shr-fhir-export/tar.gz/fbb9df698f454c3e2ef97c2aa581a9fb8e39688a"
   dependencies:
     fs-extra "^2.0.0"
     lodash "^4.17.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -548,11 +548,7 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lodash@^4.17.4, lodash@^4.3.0:
-  version "4.17.5"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
-
-lodash@^4.17.5:
+lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
@@ -630,6 +626,10 @@ onetime@^2.0.0:
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
   dependencies:
     mimic-fn "^1.0.0"
+
+opener@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/opener/-/opener-1.4.3.tgz#5c6da2c5d7e5831e8ffa3964950f8d6674ac90b8"
 
 optionator@^0.8.2:
   version "0.8.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -782,7 +782,7 @@ shr-expand@standardhealth/shr-expand#logical_models:
 
 shr-fhir-export@standardhealth/shr-fhir-export#logical_models:
   version "5.4.0"
-  resolved "https://codeload.github.com/standardhealth/shr-fhir-export/tar.gz/5ea8396e59a31354707254880ed180b3bfacf688"
+  resolved "https://codeload.github.com/standardhealth/shr-fhir-export/tar.gz/4cf0531d8931f587b40517fc632743672a7443e8"
   dependencies:
     fs-extra "^2.0.0"
     lodash "^4.17.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -552,6 +552,10 @@ lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
+lodash@^4.17.5:
+  version "4.17.5"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
+
 lru-cache@^4.0.1:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.2.tgz#45234b2e6e2f2b33da125624c4664929a0224c3f"
@@ -776,11 +780,12 @@ shr-expand@^5.4.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.4.0.tgz#0e71525b2ffc4cf63268c910da257042e49f14d5"
 
-shr-fhir-export@^5.4.0:
+shr-fhir-export@standardhealth/shr-fhir-export#logical_models:
   version "5.4.0"
-  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.4.0.tgz#3e91942b90ea884b700a677d6f34b3938d4ab431"
+  resolved "https://codeload.github.com/standardhealth/shr-fhir-export/tar.gz/22d1cc3b541b4357196f6bdc7c096bd8f405c341"
   dependencies:
     fs-extra "^2.0.0"
+    lodash "^4.17.5"
 
 shr-json-export@^5.1.4:
   version "5.1.4"
@@ -798,13 +803,13 @@ shr-json-schema-export@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/shr-json-schema-export/-/shr-json-schema-export-5.2.1.tgz#2022a19b1e0f9ccb0c06b69e8e056bfc350e6f3a"
 
-shr-models@^5.4.0:
+shr-models@standardhealth/shr-models#logical_models:
   version "5.4.0"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.4.0.tgz#6fc2542dbdb900a7e0a7d172962ce540deda190a"
+  resolved "https://codeload.github.com/standardhealth/shr-models/tar.gz/cd3b0ad011d212f8fd15d67be12dc35335d033ff"
 
-shr-text-import@^5.3.0:
+shr-text-import@standardhealth/shr-text-import#logical_models:
   version "5.3.0"
-  resolved "https://registry.yarnpkg.com/shr-text-import/-/shr-text-import-5.3.0.tgz#30b03ad00c68fbc5404111b5af3bcd99cb49b06e"
+  resolved "https://codeload.github.com/standardhealth/shr-text-import/tar.gz/3d22434daf6875d15a6563b1cbe04de14c42cea0"
   dependencies:
     antlr4 "~4.6.0"
 


### PR DESCRIPTION
Adds support for FHIR Logical models.  Note that this branch will be rebased to one single commit once approved.

This code represents the exact code used to generate the HL7 US Breast Cancer May 2018 ballot.  Note that it should be tested against standardhealth/shr_spec#may-2018-ballot-topic-context.  There are known issues testing against standardhealth/shr_spec#master, but we need to cut a release that matches exactly the toolchain used for the ballot.

This is one of seven PRs related to the logical models and HL7 ballot:
- shr-models
- shr-text-import
- shr-expand
- shr-fhir-export
- shr-json-schema-export
- shr-test-helpers
- shr-cli