### PR TITLE
5.7.1 patch release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-cli",
-  "version": "5.7.0",
+  "version": "5.7.1",
   "description": "Command-line interface for SHR tools",
   "author": "",
   "license": "Apache-2.0",
@@ -22,11 +22,11 @@
     "commander": "^2.9.0",
     "mkdirp": "^0.5.1",
     "shr-es6-export": "^5.3.1",
-    "shr-expand": "^5.5.0",
-    "shr-fhir-export": "^5.5.0",
+    "shr-expand": "^5.5.1",
+    "shr-fhir-export": "^5.5.1",
     "shr-json-export": "^5.1.4",
     "shr-json-javadoc": "^1.3.3",
-    "shr-json-schema-export": "^5.2.2",
+    "shr-json-schema-export": "^5.2.3",
     "shr-models": "^5.5.0",
     "shr-text-import": "^5.3.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -776,13 +776,13 @@ shr-es6-export@^5.3.1:
   dependencies:
     reserved-words "^0.1.2"
 
-shr-expand@^5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.5.0.tgz#add3fd793d97350bdb9ae8f1ff195ab41226a9e2"
+shr-expand@^5.5.1:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.5.1.tgz#e8d3c0cebe9bf05d663f2e90d7ff439b39f1a82c"
 
-shr-fhir-export@^5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.5.0.tgz#5d34154fefd7e76fb8bafe1024df1f0220a14889"
+shr-fhir-export@^5.5.1:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.5.1.tgz#021007503922905b33cde0282b63c26935afabf7"
   dependencies:
     fs-extra "^2.0.0"
     lodash "^4.17.5"
@@ -799,9 +799,9 @@ shr-json-javadoc@^1.3.3:
     ejs "^2.5.7"
     ncp "^2.0.0"
 
-shr-json-schema-export@^5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/shr-json-schema-export/-/shr-json-schema-export-5.2.2.tgz#20141775d14ff717bbfe220b05fe4cd2135ecfbc"
+shr-json-schema-export@^5.2.3:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/shr-json-schema-export/-/shr-json-schema-export-5.2.3.tgz#78726dba0359e99a46683710783d2b74f756925a"
 
 shr-models@^5.5.0:
   version "5.5.0"


### PR DESCRIPTION
This includes minor fixes from shr-expand, shr-json-schema-export, and
shr-fhir-export -- and fixes a crash when running against shr_spec#master.