### PR TITLE
Model-doc updates + Fixes crash when skipping fhir export

### DIFF
--- a/app.js
+++ b/app.js
@@ -284,7 +284,7 @@ if (doModelDoc && cimcoreSpecifications.dataElements.length > 0) {
   const fhirPath = `${program.out}/fhir/guide/pages/modeldoc`;
   const javadocResults = shrJDE.compileJavadoc(cimcoreSpecifications, hierarchyPath);
   shrJDE.exportToPath(javadocResults, hierarchyPath);
-  if (configSpecifications.igModelDoc == true) {
+  if (doFHIR && configSpecifications.igModelDoc == true) {
     const igJavadocResults = shrJDE.compileJavadoc(cimcoreSpecifications, hierarchyPath, true);
     shrJDE.exportToPath(igJavadocResults, fhirPath);
   }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "shr-expand": "^5.5.1",
     "shr-fhir-export": "^5.5.1",
     "shr-json-export": "^5.1.4",
-    "shr-json-javadoc": "^1.3.3",
+    "shr-json-javadoc": "^1.4.0",
     "shr-json-schema-export": "^5.2.3",
     "shr-models": "^5.5.0",
     "shr-text-import": "^5.3.1"


### PR DESCRIPTION
Cli crashes trying to compile model doc for fhir output when fhir is skipped