### PR TITLE
Updated readme for model-doc skip flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $ node . --help
     -h, --help               output usage information
     -l, --log-level <level>  the console log level <fatal,error,warn,info,debug,trace> (default: info)
     -m, --log-mode <mode>    the console log mode <short,long,json,off> (default: short)
-    -s, --skip <feature>     skip an export feature <fhir,json,cimcore,json-schema,es6,all> (default: <none>)
+    -s, --skip <feature>     skip an export feature <fhir,json,cimcore,json-schema,es6,model-doc,all> (default: <none>)
     -o, --out <out>          the path to the output folder (default: ./out)
 ```
 


### PR DESCRIPTION
In response to: https://github.com/standardhealth/shr-cli/issues/92

The tooling already has the capacity to skip the model-doc. This just adds that to the readme.

No package bump included as this is not significant enough for a release