### PR TITLE
yarn link shr-fhir-export into shr-es6-export

### DIFF
--- a/yarn-link-all
+++ b/yarn-link-all
@@ -38,6 +38,12 @@ cd ../shr-json-javadoc
 echo "============== shr-json-javadoc ===================="
 yarn link
 
+cd ../shr-fhir-export
+echo "================= shr-fhir-export =================="
+yarn link shr-models
+yarn link shr-test-helpers
+yarn link
+
 cd ../shr-es6-export
 echo "================== shr-es6-export =================="
 yarn link shr-models
@@ -45,12 +51,7 @@ yarn link shr-text-import
 yarn link shr-expand
 yarn link shr-json-schema-export
 yarn link shr-test-helpers
-yarn link
-
-cd ../shr-fhir-export
-echo "================= shr-fhir-export =================="
-yarn link shr-models
-yarn link shr-test-helpers
+yarn link shr-fhir-export
 yarn link
 
 cd ../shr-cli

--- a/yarn-unlink-all
+++ b/yarn-unlink-all
@@ -10,18 +10,19 @@ yarn unlink shr-text-import
 yarn unlink shr-expand
 yarn unlink shr-models
 
-cd ../shr-fhir-export
-echo "================= shr-fhir-export =================="
-yarn unlink shr-models
-yarn unlink shr-test-helpers
-yarn unlink
-
 cd ../shr-es6-export
 echo "================== shr-es6-export =================="
 yarn unlink shr-models
 yarn unlink shr-text-import
 yarn unlink shr-expand
 yarn unlink shr-json-schema-export
+yarn unlink shr-test-helpers
+yarn unlink shr-fhir-export
+yarn unlink
+
+cd ../shr-fhir-export
+echo "================= shr-fhir-export =================="
+yarn unlink shr-models
 yarn unlink shr-test-helpers
 yarn unlink
 


### PR DESCRIPTION
Now that FHIR data is needed for ES6 class generation, `shr-fhir-export` should get `yarn link`-d into `shr-es6-export` for development. Updated `yarn-link-all` and `yarn-unlink-all` accordingly.