### PR TITLE
Update travis node version, and change to run against shr_spec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: node_js
 node_js:
-- '6'
+  - '8'
 notifications:
   slack:
     secure: V7hKbKUg0W2M0InbQuYVV/f98FnuMpP+a8cvDWkLsyI4fiHwaPhq0toAoRRRd2j2Jp6AFsvvaFEW4QhbZecs9UDvFNnVWgma/mvZSs8VhnqSONcw7eD+e6ITF5H5DsPGKZ0pKR95msOyLC9OB2LL9vVxnF2uQOM0pHavCDDHptHcMjdbcBytTSuWntnRDbQ3jLhJfjzi2bjOmgr64XqEtu/0KjqaokEB4p34N9UmybLtYYrQJ+gy7TjeT1K0BDotSe9DmklCJbW51Jok3kKeNHzgymn3AHMEIo6JGY83GwHllba6SIieYnjrCjrtKtDMcxBXOxM1IGYfAEgZvXZ42SW3xHfVh6xOz/wnV8uoaqm5fpTCjQ2Owv0fOKf4Ru/4FMuX0XyVeEKDyBEtKk1O86s5XEX+m+r9vGTxi4K1I4FUq62/pqwxSeNKfoBlWixQUrHOkIn9/xhasDhAFDGOIqyTlOMAyLtpZTYTX1+XNRgFTbVsNHPlmWUsDX1Sg+h2pd5pQAIUU3pfbzOZI0bjYfSB40VOJCnvffU4PozonTa1rjEB7X1zFHIR1Xvn8Mka/MdbPYzgEmDrhFrXCUsznhhIp4GreYisAIYIo0qLxBhZY/YjPjQJA/3Cc2+xU86cyUp8TRFnnQjhfyq8H24S++Delx+X4H39/vmu87/YVgo=
+before_install:
+  - git clone https://github.com/standardhealth/shr_spec.git
+script:
+  - node . shr_spec/spec/


### PR DESCRIPTION
The `.travis.yml` used to be configured to run 'yarn test' as a default, but this caused the build to fail, since the command did not exist. This changes the travis build to run against the most recent version of the `shr_spec`. This also updates node in the travis build from 6 to 8.

Currently, this will cause the build to pass regardless of how many errors and warnings there are, as long as the operation doesn't crash. We may want to expand this operation to be more thorough, but it is functional as a starting point.