### PR TITLE
Try catch failure catching

### DIFF
--- a/app.js
+++ b/app.js
@@ -372,7 +372,7 @@ if (wrnCounter.count > 0) {
 const hrend = process.hrtime(hrstart);
 console.log('------------------------------------------------------------');
 console.log('Elapsed time: %d.%ds', hrend[0], Math.floor(hrend[1]/1000000));
-console.log('%s%d %s%s', errColor, ftlCounter.count, ftlLabel, resetColor);
+if (ftlCounter.count > 0) console.log('%s%d %s%s', errColor, ftlCounter.count, ftlLabel, resetColor);
 console.log('%s%d %s%s', errColor, errCounter.count, errLabel, resetColor);
 console.log('%s%d %s%s', wrnColor, wrnCounter.count, wrnLabel, resetColor);
 console.log('------------------------------------------------------------');


### PR DESCRIPTION
I added the try catch protection to each of the exporters. 

I'm not happy with how I'm ultimately displaying a failure:
```
------------------------------------------------------------
Elapsed time: 3.97s
465 errors (shr-expand, failure in 1 exporter(s) [Model Doc])
5 warnings (shr-text-input, shr-json-schema-export)
------------------------------------------------------------
```

Do you have any suggestions for a better message?

(P.S. Don't mind the actual error numbers, I was intentionally breaking exporters so that's not reflective of a clean build.)