### PR TITLE
v5.9.1 - w/ shr-text-import 5.4.1 & shr-fhir-export 5.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ On Windows:
 
 # Configuration File
 
-The SHR tools require a configuration file in the path to the SHR specification definitions. Configuration files *must* end in the characters `config.json` or `config.txt` or else they will not be recognized by the tools.
+The SHR tools require a configuration file in the path to the SHR specification definitions. Configuration files *must* be valid JSON, have at least the `projectName` property, and use the `.json` file extension.
 
-If a configuration file name is specified using the `-c` command line option, the SHR tools look for a file with this name in the specification definitions directory. If no configuration file is specified at startup, the SHR tools look for a file called `config.json` in this directory. If the desired file doesn't exist, the tools use the first configuration file found in the specification definitions directory. If no configuration file exists in this directory, a default `config.json` file is auto-generated and used.
+If a configuration file name is specified using the `-c` command line option, the SHR tools look for a file with this name in the specification definitions directory. If it cannot be found or it is an invalid configuration file, an error is returned. If no configuration file is specified at startup, the SHR tools look for a file called `config.json` in this directory. If it is not found, a default `config.json` file is auto-generated and used.
 
 The contents of the configuration file are as follows:
 

--- a/app.js
+++ b/app.js
@@ -102,6 +102,9 @@ if (doModelDoc) {
 // Go!
 logger.info('Starting CLI Import/Export');
 const configSpecifications = shrTI.importConfigFromFilePath(input, program.config);
+if (!configSpecifications) {
+  process.exit(1);
+}
 configSpecifications.showDuplicateErrors = showDuplicateErrors;
 let specifications = shrTI.importFromFilePath(input, configSpecifications);
 let expSpecifications = shrEx.expand(specifications, shrFE);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-cli",
-  "version": "5.9.0",
+  "version": "5.9.1",
   "description": "Command-line interface for SHR tools",
   "author": "",
   "license": "Apache-2.0",
@@ -23,12 +23,12 @@
     "mkdirp": "^0.5.1",
     "shr-es6-export": "^5.4.1",
     "shr-expand": "^5.5.1",
-    "shr-fhir-export": "^5.6.0",
+    "shr-fhir-export": "^5.6.1",
     "shr-json-export": "^5.1.4",
     "shr-json-javadoc": "^1.4.2",
     "shr-json-schema-export": "^5.3.0",
     "shr-models": "^5.5.2",
-    "shr-text-import": "^5.4.0"
+    "shr-text-import": "^5.4.1"
   },
   "devDependencies": {
     "eslint": "^4.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -927,9 +927,9 @@ shr-expand@^5.5.1:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.5.1.tgz#e8d3c0cebe9bf05d663f2e90d7ff439b39f1a82c"
 
-shr-fhir-export@^5.6.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.6.0.tgz#3e3e3398c7cb7cfc5ac1aa8a96ae26da10e94fd1"
+shr-fhir-export@^5.6.1:
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.6.1.tgz#acb6380380d7b626c7d8b73cd8358d035fcc6e98"
   dependencies:
     fs-extra "^2.0.0"
     lodash "^4.17.5"
@@ -955,9 +955,9 @@ shr-models@^5.5.2:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.5.2.tgz#8871fa8626278a53dc729fc04512aaf2acf91b94"
 
-shr-text-import@^5.4.0:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/shr-text-import/-/shr-text-import-5.4.0.tgz#9b131b279e2af6aad61709b13ea0f2286a229487"
+shr-text-import@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/shr-text-import/-/shr-text-import-5.4.1.tgz#ee708eef697b285f5c7decda5dc982e07c58fd38"
   dependencies:
     antlr4 "~4.6.0"
 


### PR DESCRIPTION
Takes in fix for selecting config file, deduplication of a FHIR warning, and change to how namespace primary selection strategy works.