### PR TITLE
Hybrid filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,11 +135,11 @@ The contents of the `implementationGuide` object's `primarySelectionStrategy` ob
 
 The contents of the `filterStrategy` object are as follows:
 
-|Parameter |Type     |Description                                                             |
-|:---------|:--------|:-----------------------------------------------------------------------|
-|`filter`  |`boolean`|A value indicating whether to enable filtering.                         |
-|`strategy`|`string` |The strategy for specification filtering (`"namespace"` or `"element"`).|
-|`target`  |`[]`     |An array of strings containing the names for what to filter.            |
+|Parameter |Type     |Description                                                                          |
+|:---------|:--------|:------------------------------------------------------------------------------------|
+|`filter`  |`boolean`|A value indicating whether to enable filtering.                                      |
+|`strategy`|`string` |The strategy for specification filtering (`"namespace"`, `"element"`, or `"hybrid"`).|
+|`target`  |`[]`     |An array of strings containing the names for what to filter.                         |
 
 # License
 

--- a/filter.js
+++ b/filter.js
@@ -26,8 +26,7 @@ class SpecificationsFilter {
     // recursively find dependencies for each data element in specifications
     // if element matches filter criteria
     for (const element of this._expSpecs.dataElements.all) {
-      if (((strategy === 'element') && (target.includes(element.identifier.name)))
-      || ((strategy === 'namespace') && (target.includes(element.identifier.namespace)))) {
+      if (this.meetsFilterCriteria(strategy, target, element)) {
         this.findDataElementDependenciesRecursive(element.identifier);
       }
     }
@@ -121,6 +120,19 @@ class SpecificationsFilter {
     }
 
     return [this._filteredSpecs, this._filteredExpSpecs];
+  }
+
+  meetsFilterCriteria(strategy, target, element) {
+    switch(strategy) {
+      case 'element':
+        return target.includes(element.identifier.name);
+      case 'namespace':
+        return target.includes(element.identifier.namespace);
+      case 'hybrid':
+        return (target.includes(element.identifier.name) || target.includes(element.identifier.namespace));
+      default:
+        return false;
+    }
   }
 
   findDataElementDependenciesRecursive(identifier) {


### PR DESCRIPTION
Adds a `"hybrid"` filter `strategy`. This filters based on element **and** namespace. By entering strings into the `target` array in the config file, as long as an element's name **or** namespace matches one of the target strings, it meets the filter criteria.