### PR TITLE
Added shr-json-javadoc and shr-adl-bmm-export to some scripts 

### DIFF
--- a/pull-all
+++ b/pull-all
@@ -28,12 +28,20 @@ cd ../shr-json-schema-export
 echo "============== shr-json-schema-export =============="
 git pull
 
+cd ../shr-json-javadoc
+echo "============== shr-json-javadoc =============="
+git pull
+
 cd ../shr-es6-export
 echo "================== shr-es6-export =================="
 git pull
 
 cd ../shr-fhir-export
 echo "================= shr-fhir-export =================="
+git pull
+
+cd ../shr-adl-bmm-export
+echo "================= shr-adl-bmm-export =================="
 git pull
 
 cd ../shr-cli

--- a/rebuild-all
+++ b/rebuild-all
@@ -45,6 +45,11 @@ echo "================= shr-fhir-export =================="
 rm -rf node_modules
 yarn
 
+cd ../shr-adl-bmm-export
+echo "================= shr-adl-bmm-export =================="
+rm -rf node_modules
+yarn
+
 cd ../shr-cli
 echo "===================== shr-cli ======================"
 rm -rf node_modules


### PR DESCRIPTION
`pull-all` and `rebuild-all` were missing some of the child `shr-` packages. This PR adds them in where necessary.