### PR TITLE
v5.12.1: Update shr-fhir-export to 5.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "shr-adl-bmm-export": "^1.0.1",
     "shr-es6-export": "^5.4.2",
     "shr-expand": "^5.7.0",
-    "shr-fhir-export": "^5.8.0",
+    "shr-fhir-export": "^5.8.1",
     "shr-json-export": "^5.1.5",
     "shr-json-javadoc": "^1.4.4",
     "shr-json-schema-export": "^5.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-cli",
-  "version": "5.12.0",
+  "version": "5.12.1",
   "description": "Command-line interface for SHR tools",
   "author": "",
   "license": "Apache-2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -953,9 +953,9 @@ shr-expand@^5.7.0:
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.7.0.tgz#a9bd0d2c099dada0345b734613252c55e61710ba"
 
-shr-fhir-export@^5.8.0:
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.8.0.tgz#2c9b3b6b67dbe6cf5b49b83e63cc1ffd01431441"
+shr-fhir-export@^5.8.1:
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.8.1.tgz#5b352a7f67feb8017f65d854b0732ec7d7060bfa"
   dependencies:
     fs-extra "^2.0.0"
     lodash "^4.17.5"


### PR DESCRIPTION
This shr-fhir-export takes in a bug fix related to finding mapping targets in FHIR profiles.