### PR TITLE
Mcode fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "shr-adl-bmm-export": "^1.0.1",
     "shr-es6-export": "^5.4.2",
     "shr-expand": "^5.7.0",
-    "shr-fhir-export": "^5.8.1",
+    "shr-fhir-export": "^5.9.0-beta.1",
     "shr-json-export": "^5.1.5",
     "shr-json-javadoc": "^1.4.4",
     "shr-json-schema-export": "^5.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-cli",
-  "version": "5.13.0-beta.1",
+  "version": "5.13.0",
   "description": "Command-line interface for SHR tools",
   "author": "",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-cli",
-  "version": "5.12.1",
+  "version": "5.13.0-beta.1",
   "description": "Command-line interface for SHR tools",
   "author": "",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "shr-adl-bmm-export": "^1.0.1",
     "shr-es6-export": "^5.4.2",
     "shr-expand": "^5.7.0",
-    "shr-fhir-export": "^5.9.0-beta.1",
+    "shr-fhir-export": "^5.9.0",
     "shr-json-export": "^5.1.5",
     "shr-json-javadoc": "^1.4.4",
     "shr-json-schema-export": "^5.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -953,9 +953,10 @@ shr-expand@^5.7.0:
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.7.0.tgz#a9bd0d2c099dada0345b734613252c55e61710ba"
 
-shr-fhir-export@^5.8.1:
-  version "5.8.1"
-  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.8.1.tgz#5b352a7f67feb8017f65d854b0732ec7d7060bfa"
+shr-fhir-export@^5.9.0-beta.1:
+  version "5.9.0-beta.1"
+  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.9.0-beta.1.tgz#ebb66c446a1006afe6ecfefe636f2bf18cffbbca"
+  integrity sha512-s3Rug26wPyyAm4+AajlbOD0gkcSovDCGnIJlwoDVC36u3egi9dHtLgBJ9sOcg7O7eayh3/ZRZjgycUsJgJ/okA==
   dependencies:
     fs-extra "^2.0.0"
     lodash "^4.17.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -953,10 +953,10 @@ shr-expand@^5.7.0:
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.7.0.tgz#a9bd0d2c099dada0345b734613252c55e61710ba"
 
-shr-fhir-export@^5.9.0-beta.1:
-  version "5.9.0-beta.1"
-  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.9.0-beta.1.tgz#ebb66c446a1006afe6ecfefe636f2bf18cffbbca"
-  integrity sha512-s3Rug26wPyyAm4+AajlbOD0gkcSovDCGnIJlwoDVC36u3egi9dHtLgBJ9sOcg7O7eayh3/ZRZjgycUsJgJ/okA==
+shr-fhir-export@^5.9.0:
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.9.0.tgz#4ac90fb16ec7490d70cbdb57d6f4bbbaf3f21ce7"
+  integrity sha512-o6/4EYsJ88ZzjC1IpZR+HarP9r1t7VmMgZn/Diws3B0HlYdSTtxhKUfxxuuG76wIOCxyfdrHlbK8y5wzNSZiYQ==
   dependencies:
     fs-extra "^2.0.0"
     lodash "^4.17.5"


### PR DESCRIPTION
Upgrade to shr-fhir-export 5.9.0 w/ corresponding changes ([doc](https://github.com/standardhealth/shr-fhir-export/releases/tag/v5.9.0)).