### PR TITLE
Must Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,39 @@ The options for the configuration file's `implementationGuide.primarySelectionSt
 
 When specifying a namespace or element in the `primary` array, it is best to use the fully qualified name (FQN) format for doing so. For example, a namespace could be `"shr.oncology"` and an element could be `"shr.oncology.BreastCancerStage"`.
 
+## Content Profile
+
+The content profile allows authors to indicate the fields and paths that should be marked as "Must Support".  Future versions of content profiles will allow for additional features.
+
+The following demonstrates the correct format for a content profile file:
+```
+Grammar: ContentProfile 1.0
+
+Namespace: shr.core
+    Patient:
+        Person.DateOfBirth MS
+        Person.AdministrativeGender MS
+        Person.Race MS
+        Person.Ethnicity MS
+        Person.Address.PostalCode MS
+        Person.Deceased MS
+    ComorbidCondition:
+        PatientSubjectOfRecord MS
+        Code MS
+        ClinicalStatus MS
+    // ... more ...
+
+Namespace: oncocore
+    CancerCondition:
+        PatientSubjectOfRecord MS
+        Code MS
+        ClinicalStatus MS
+        BodyLocation.LocationCode MS
+        MorphologyBehavior MS
+        DateOfDiagnosis MS
+    // ... more ...
+```
+
 # License
 
 Copyright 2016, 2017 The MITRE Corporation

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ When using this command-line interface and IG publisher, the general order of op
 3. CLI exports the filtered SHR definitions into desired formats, such as ES6, JSON, FHIR, etc. The exports can be selected through command line options, as explained above.
 4. (separate, optional step) The IG publisher takes the SHR FHIR export and generates an IG from the information in these files, following the `implementationGuide` configuration (see below).
 
-To control this process, CLI requires a configuration file. Configuration files *must* be valid JSON, have at least the `projectName` property, and use the `.json` file extension. The configuration file must be located in the path to the SHR specification definitions. 
+To control this process, CLI requires a configuration file. Configuration files *must* be valid JSON, have at least the `projectName` property, and use the `.json` file extension. The configuration file must be located in the path to the SHR specification definitions.
 
 If a configuration file name is specified using the `-c` command line option, the SHR tools look for a file with this name in the specification definitions directory. If it cannot be found or it is an invalid configuration file, an error is returned. If no configuration file is specified at startup, the SHR tools look for a file called `config.json` in this directory. If it is not found, a default `config.json` file is auto-generated and used.
 
@@ -122,6 +122,7 @@ The contents of the configuration file are as follows:
 |`fhirTarget`         |`string`|The FHIR target for the project (`FHIR_STU_3` or `FHIR_DSTU_2`)|
 |`entryTypeURL`       |`string`|The root URL for the JSON schema `EntryType` field.            |
 |`filterStrategy`     |`{}`    |An object containing configuration for filtering.              |
+|`contentProfile`     |`string`|The base file name for the content profile for the project.    |
 |`implementationGuide`|`{}`    |An object containing configuration for IG publishing.          |
 |`publisher`          |`string`|The name of the publisher for the project.                     |
 |`contact`            |`[]`    |The array of FHIR `ContactPoint`s to reach about the project.  |
@@ -157,11 +158,11 @@ The contents of the `filterStrategy` object are as follows:
 * If `filter` is `true`, then the filtering operation will occur. Otherwise, no filtering will occur.
 * If there is no `filterStrategy` or `strategy`, filtering will not occur.
 
-When specifying a namespace or element in the `target` array, it is best to use the fully qualified name (FQN) format for doing so. For example, a namespace could be `"shr.oncology"` and an element could be `"shr.oncology.BreastCancerStage"`. 
+When specifying a namespace or element in the `target` array, it is best to use the fully qualified name (FQN) format for doing so. For example, a namespace could be `"shr.oncology"` and an element could be `"shr.oncology.BreastCancerStage"`.
 
 ## Implementation Guide Configuration
 These configurations are used to highlight specific elements as more important in the IG. This is where the `implementationGuide` configuration comes into play.
- 
+
 The contents of the `implementationGuide` object are as follows:
 
 |Parameter                 |Type     |Description                                                    |

--- a/filter.js
+++ b/filter.js
@@ -86,6 +86,11 @@ class SpecificationsFilter {
       }
     }
 
+    // Just copy over the content profiles untouched
+    for (const cp of this._expSpecs.contentProfiles.all) {
+      this._filteredExpSpecs.contentProfiles.add(cp.clone());
+    }
+
     // In some cases (like cimcore import, this._specs may be null)
     if (this._specs != null) {
       // filter specifications based on filtered expanded specifications
@@ -116,6 +121,10 @@ class SpecificationsFilter {
             this._filteredSpecs.maps.add(map);
           }
         }
+      }
+      // Just copy over the content profiles untouched
+      for (const cp of this._specs.contentProfiles.all) {
+        this._filteredSpecs.contentProfiles.add(cp.clone());
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-cli",
-  "version": "5.16.1",
+  "version": "5.17.0",
   "description": "Command-line interface for SHR tools",
   "author": "",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -24,13 +24,13 @@
     "mkdirp": "^0.5.1",
     "shr-adl-bmm-export": "^1.0.1",
     "shr-es6-export": "^5.5.1",
-    "shr-expand": "^5.7.0",
-    "shr-fhir-export": "^5.12.1",
+    "shr-expand": "^5.8.0",
+    "shr-fhir-export": "^5.13.0",
     "shr-json-export": "^5.1.5",
     "shr-json-javadoc": "^1.4.5",
     "shr-json-schema-export": "^5.3.2",
-    "shr-models": "^5.7.0",
-    "shr-text-import": "^5.6.0"
+    "shr-models": "^5.8.0",
+    "shr-text-import": "^5.7.0"
   },
   "devDependencies": {
     "eslint": "^4.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1117,15 +1117,15 @@ shr-es6-export@^5.5.1:
   dependencies:
     reserved-words "^0.1.2"
 
-shr-expand@^5.7.0:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.7.0.tgz#a9bd0d2c099dada0345b734613252c55e61710ba"
-  integrity sha512-wUJDV/uusXSM3ZSUTY1xsGhO5XTZcIvUqYC0r2lQBOIlkF76CmFNW048c1av5gJwjTD1s534PYKcM65jGxPWqw==
+shr-expand@^5.8.0:
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.8.0.tgz#ba4e6feb9f042c0b1e62ff274441dc835a3fc15d"
+  integrity sha512-POC1DclInP5d8oRj0yup5InIQw7P9YENIcWEV2iHYnjlLvN21wnj259UQKTRwltVDUqgninYRPR/z2ZA15901g==
 
-shr-fhir-export@^5.12.1:
-  version "5.12.1"
-  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.12.1.tgz#cff6d381d32bb3428c192ccf93a6b4d7e9ea62c5"
-  integrity sha512-9K+9u62EecXN9lal3d3wB0aLmPDSjh/o80hmB33aDNdrSXc3Cuu9MrtD+v6oF+hgkJGPxlcz19gCphrPVXHhDA==
+shr-fhir-export@^5.13.0:
+  version "5.13.0"
+  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.13.0.tgz#3a87a38eff152e05765981a997e0ad81f520fcde"
+  integrity sha512-QuTCzcxP/pooU1P0M5jDx0L2IxNhZx1M1Po594MqX21/sUm+D5jQ15NsV4PFY+4emf7lYf0hdFXjUoYhRd2G3w==
   dependencies:
     fs-extra "^2.0.0"
     lodash "^4.17.5"
@@ -1150,15 +1150,15 @@ shr-json-schema-export@^5.3.2:
   resolved "https://registry.yarnpkg.com/shr-json-schema-export/-/shr-json-schema-export-5.3.2.tgz#8840b62eb6a882cb242043e93733e1f3bd472a21"
   integrity sha512-sv8TF5VNh/JlJg5M7ZtPUSuKrKrjSsrUg11JYtpWevvfSwyfgM3T0KkL9bsyoAr1QCLwYRiosZFV89FZDregEA==
 
-shr-models@^5.7.0:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.7.0.tgz#53856c17017ffb98a5a6d58296dd2201692d9762"
-  integrity sha512-uiyEO1PVnyxT8mu9v/8PbfN3rgY7k/qXtrKfU/Tdz/ePoRx+VLEbl25I3eWAbdwGb7QhbztMJ9z4l67/MvBoOA==
+shr-models@^5.8.0:
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.8.0.tgz#b2438c52340f1e167513334169d51c88bdcef5e7"
+  integrity sha512-2s5aHeXUptIfrCWPKPw27weIV5GCVyy3yXRXCxUJ+EOAJDQpyHiH54sxvCWaJ8hnRKVC+XSfx1qTMerV+T2itA==
 
-shr-text-import@^5.6.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/shr-text-import/-/shr-text-import-5.6.0.tgz#b5d733a4160c86850efad6ea60acd1b2a1818b13"
-  integrity sha512-I5mZ4Fw10c4JTMtYAnUy04t7adkfnOufyMwFf8kaKwyp64kNpGZ0ByOlbAybgWUr9lc2LmdzoAVE/zSYdfrsbA==
+shr-text-import@^5.7.0:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/shr-text-import/-/shr-text-import-5.7.0.tgz#e2ab11b1fa183aa5a06b4b751205da8e1800b307"
+  integrity sha512-58PQXDA/JWoVDNGmnAbZM/bQyD6C/QLfp2B6HfDR6dCuixa2M9fpDnInnzfIKd6wFi3OLv3Z8jJtb4NjnnykZA==
   dependencies:
     antlr4 "~4.6.0"
 


### PR DESCRIPTION
PR 1/4 for `must-support`.

Adds a line to the README to explain how to operate the config file option for `contentProfile`.