### PR TITLE
Nested extension paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "shr-adl-bmm-export": "^1.0.1",
     "shr-es6-export": "^5.5.1",
     "shr-expand": "^5.7.0",
-    "shr-fhir-export": "^5.11.2",
+    "shr-fhir-export": "^5.12.0-beta.1",
     "shr-json-export": "^5.1.5",
     "shr-json-javadoc": "^1.4.5",
     "shr-json-schema-export": "^5.3.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "shr-adl-bmm-export": "^1.0.1",
     "shr-es6-export": "^5.5.1",
     "shr-expand": "^5.7.0",
-    "shr-fhir-export": "^5.12.0-beta.1",
+    "shr-fhir-export": "^5.12.0",
     "shr-json-export": "^5.1.5",
     "shr-json-javadoc": "^1.4.5",
     "shr-json-schema-export": "^5.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-cli",
-  "version": "5.16.0-beta.1",
+  "version": "5.16.0",
   "description": "Command-line interface for SHR tools",
   "author": "",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-cli",
-  "version": "5.15.3",
+  "version": "5.16.0-beta.1",
   "description": "Command-line interface for SHR tools",
   "author": "",
   "license": "Apache-2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1122,10 +1122,10 @@ shr-expand@^5.7.0:
   resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.7.0.tgz#a9bd0d2c099dada0345b734613252c55e61710ba"
   integrity sha512-wUJDV/uusXSM3ZSUTY1xsGhO5XTZcIvUqYC0r2lQBOIlkF76CmFNW048c1av5gJwjTD1s534PYKcM65jGxPWqw==
 
-shr-fhir-export@^5.11.2:
-  version "5.11.2"
-  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.11.2.tgz#bccda896d7a167c82fbfd12e71c06fb9324296fc"
-  integrity sha512-S6xoOQj3fUi6NXIqAHNfSeQKRBSP0X46Vmsl0bM6OtMpSDfjJbzEyv14bcaLWW9+REb9cLp56bMwh2mizTtLYg==
+shr-fhir-export@^5.12.0-beta.1:
+  version "5.12.0-beta.1"
+  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.12.0-beta.1.tgz#5bb4c0dfe460de05a7629b5e69f84ad112bbf172"
+  integrity sha512-Kk/VAQuo3bBLzQkO69BT95BtLF2N4IhOzpezzNaxgWIdUyDSza+IiTJnTHy3XDXt1OsBDN484fWhoB74GgAhFQ==
   dependencies:
     fs-extra "^2.0.0"
     lodash "^4.17.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1122,10 +1122,10 @@ shr-expand@^5.7.0:
   resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.7.0.tgz#a9bd0d2c099dada0345b734613252c55e61710ba"
   integrity sha512-wUJDV/uusXSM3ZSUTY1xsGhO5XTZcIvUqYC0r2lQBOIlkF76CmFNW048c1av5gJwjTD1s534PYKcM65jGxPWqw==
 
-shr-fhir-export@^5.12.0-beta.1:
-  version "5.12.0-beta.1"
-  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.12.0-beta.1.tgz#5bb4c0dfe460de05a7629b5e69f84ad112bbf172"
-  integrity sha512-Kk/VAQuo3bBLzQkO69BT95BtLF2N4IhOzpezzNaxgWIdUyDSza+IiTJnTHy3XDXt1OsBDN484fWhoB74GgAhFQ==
+shr-fhir-export@^5.12.0:
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.12.0.tgz#74bb73471bf3557c32cac22246677d3b92dc1b41"
+  integrity sha512-f7qsSiwDCjmG+DoF4nQHJAsc60N0BLIJRncGUWZ1H1UK4zVPrf4oKOm+VkYhqfq8Dd9g8X1IraYtmeX+92Y/xg==
   dependencies:
     fs-extra "^2.0.0"
     lodash "^4.17.5"


### PR DESCRIPTION
Version 5.16.0 updates shr-fhir-export to 5.12.0, adding support for using extension ids in paths.  This allows constraining or mapping to nested extensions.  For example:

```
DTR-Questionnaire maps to http://hl7.org/fhir/StructureDefinition/cqif-questionnaire:
    PayerLibrary maps to http://hl7.org/fhir/StructureDefinition/cqif-library
    constrain item.extension[cqif-initialValue] to 1..1
    constrain item.extension[cqif-calculatedValue] to 1..1
    DTR-QuestionnaireItem.CalculatedValue maps to item.extension[cqif-calculatedValue].valueString
```