### PR TITLE
Fix mcode bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,15 @@ After exporting the SHR definitions, the FHIR Implementation Guide (IG) Publishe
 $ yarn run ig:publish
 ```
 
-NOTE: The FHIR IG publishing tool uses a _lot_ of memory when processing the full set of SHR definitions.  The yarn script above will allocated up to 8GB of RAM. A minimum of 4GB of RAM is recommended to run the tool.
+NOTE: The FHIR IG Publisher tool uses a _lot_ of memory when processing the full set of SHR definitions.  The yarn script above will allocated up to 8GB of RAM. A minimum of 4GB of RAM is recommended to run the tool.
 
 # Creating the FHIR Implementation Guide Using an HTTP Proxy
 
-If your system requires a proxy to access the internet, you'll need to take a more complex approach than above.
+**NOTE: The current version of the FHIR IG Publisher tool does not properly support HTTP proxies.** This has been logged in FHIR's GForge tracker as issue [#19815](https://gforge.hl7.org/gf/project/fhir/tracker/?action=TrackerItemEdit&tracker_item_id=19815).  To properly run the IG Publisher, you need to be in an environment that does not require a proxy.
 
-First, export a system environment variable called JAVA_OPTS, setting the proxies as appropriate.
+If you *must* run the IG Publisher in a proxy environment, you can download an earlier version of the publisher (with working proxy support) here: [IGPublisher (Oct 10 2018)](https://github.com/standardhealth/shr-fhir-export/raw/a4a66550605e75a1a28746c7961f830ab339b84b/lib/ig_files/org.hl7.fhir.igpublisher.jar). _NOTE: You will be missing any bug fixes and enhancements made to the publisher since October 2018, and we do not recommend using this for actual publishing._
+
+To use the old (but proxy-friendly) IG Publisher, export a system environment variable called JAVA_OPTS, setting the proxies as appropriate.
 
 On Mac or Linux:
 ```
@@ -87,16 +89,16 @@ On Windows:
 > SET JAVA_OPTS=-Dhttp.proxyHost=my.proxy.org -Dhttp.proxyPort=80 -Dhttps.proxyHost=my.proxy.org -Dhttps.proxyPort=80 -DsocksProxyHost=my.proxy.org -DsocksProxyPort=80
 ```
 
-Next, create the IG using the HL7 IG Publisher Tool.
+Next, create the IG using the old October 2018 HL7 IG Publisher Tool.
 
 On Mac or Linux:
 ```
-$ java $JAVA_OPTS -Xms4g -Xmx8g -jar out/fhir/guide/org.hl7.fhir.igpublisher.jar -ig out/fhir/guide/ig.json
+$ java $JAVA_OPTS -Xms4g -Xmx8g -jar path/to/old/org.hl7.fhir.igpublisher.jar -ig out/fhir/guide/ig.json
 ```
 
 On Windows:
 ```
-> java %JAVA_OPTS% -Xms4g -Xmx8g -jar out/fhir/guide/org.hl7.fhir.igpublisher.jar -ig out/fhir/guide/ig.json
+> java %JAVA_OPTS% -Xms4g -Xmx8g -jar path/to/old/org.hl7.fhir.igpublisher.jar -ig out/fhir/guide/ig.json
 ```
 
 # Configuration File

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-cli",
-  "version": "5.17.0",
+  "version": "5.17.1-beta.3",
   "description": "Command-line interface for SHR tools",
   "author": "",
   "license": "Apache-2.0",
@@ -25,7 +25,7 @@
     "shr-adl-bmm-export": "^1.0.1",
     "shr-es6-export": "^5.5.1",
     "shr-expand": "^5.8.0",
-    "shr-fhir-export": "^5.13.0",
+    "shr-fhir-export": "^5.13.1",
     "shr-json-export": "^5.1.5",
     "shr-json-javadoc": "^1.4.5",
     "shr-json-schema-export": "^5.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-cli",
-  "version": "5.17.1-beta.3",
+  "version": "5.17.1",
   "description": "Command-line interface for SHR tools",
   "author": "",
   "license": "Apache-2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1122,10 +1122,10 @@ shr-expand@^5.8.0:
   resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.8.0.tgz#ba4e6feb9f042c0b1e62ff274441dc835a3fc15d"
   integrity sha512-POC1DclInP5d8oRj0yup5InIQw7P9YENIcWEV2iHYnjlLvN21wnj259UQKTRwltVDUqgninYRPR/z2ZA15901g==
 
-shr-fhir-export@^5.13.0:
-  version "5.13.0"
-  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.13.0.tgz#3a87a38eff152e05765981a997e0ad81f520fcde"
-  integrity sha512-QuTCzcxP/pooU1P0M5jDx0L2IxNhZx1M1Po594MqX21/sUm+D5jQ15NsV4PFY+4emf7lYf0hdFXjUoYhRd2G3w==
+shr-fhir-export@^5.13.1:
+  version "5.13.1"
+  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.13.1.tgz#3ff2a34abe34ece1629149718c7c06cf74c51f71"
+  integrity sha512-Qzac3jGBOxaBgTvS6/5XTQtOGiWzZ4DlmZhbbxV9LCluVRn1hs1Sf0IFsFnPi9v5F2z4RDymPGAQUbAZH9I5Tg==
   dependencies:
     fs-extra "^2.0.0"
     lodash "^4.17.5"


### PR DESCRIPTION
Upgrades shr-fhir-export to v5.13.1 (see: [shr-fhir-export@5.13.1 release notes](https://github.com/standardhealth/shr-fhir-export/releases/tag/v5.13.1))