### PR TITLE
CIMPL6 Import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ before_install:
   - git clone https://github.com/standardhealth/shr_spec.git
   - git --git-dir ./shr_spec checkout dev6
 script:
-  - node . shr_spec/spec/
+  - node . -s es6 shr_spec/spec/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ notifications:
     secure: V7hKbKUg0W2M0InbQuYVV/f98FnuMpP+a8cvDWkLsyI4fiHwaPhq0toAoRRRd2j2Jp6AFsvvaFEW4QhbZecs9UDvFNnVWgma/mvZSs8VhnqSONcw7eD+e6ITF5H5DsPGKZ0pKR95msOyLC9OB2LL9vVxnF2uQOM0pHavCDDHptHcMjdbcBytTSuWntnRDbQ3jLhJfjzi2bjOmgr64XqEtu/0KjqaokEB4p34N9UmybLtYYrQJ+gy7TjeT1K0BDotSe9DmklCJbW51Jok3kKeNHzgymn3AHMEIo6JGY83GwHllba6SIieYnjrCjrtKtDMcxBXOxM1IGYfAEgZvXZ42SW3xHfVh6xOz/wnV8uoaqm5fpTCjQ2Owv0fOKf4Ru/4FMuX0XyVeEKDyBEtKk1O86s5XEX+m+r9vGTxi4K1I4FUq62/pqwxSeNKfoBlWixQUrHOkIn9/xhasDhAFDGOIqyTlOMAyLtpZTYTX1+XNRgFTbVsNHPlmWUsDX1Sg+h2pd5pQAIUU3pfbzOZI0bjYfSB40VOJCnvffU4PozonTa1rjEB7X1zFHIR1Xvn8Mka/MdbPYzgEmDrhFrXCUsznhhIp4GreYisAIYIo0qLxBhZY/YjPjQJA/3Cc2+xU86cyUp8TRFnnQjhfyq8H24S++Delx+X4H39/vmu87/YVgo=
 before_install:
   - git clone https://github.com/standardhealth/shr_spec.git
-  - git --git-dir ./shr_spec checkout dev6
+  - git -C ./shr_spec checkout dev6
 script:
   - node . -s es6 shr_spec/spec/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,6 @@ notifications:
     secure: V7hKbKUg0W2M0InbQuYVV/f98FnuMpP+a8cvDWkLsyI4fiHwaPhq0toAoRRRd2j2Jp6AFsvvaFEW4QhbZecs9UDvFNnVWgma/mvZSs8VhnqSONcw7eD+e6ITF5H5DsPGKZ0pKR95msOyLC9OB2LL9vVxnF2uQOM0pHavCDDHptHcMjdbcBytTSuWntnRDbQ3jLhJfjzi2bjOmgr64XqEtu/0KjqaokEB4p34N9UmybLtYYrQJ+gy7TjeT1K0BDotSe9DmklCJbW51Jok3kKeNHzgymn3AHMEIo6JGY83GwHllba6SIieYnjrCjrtKtDMcxBXOxM1IGYfAEgZvXZ42SW3xHfVh6xOz/wnV8uoaqm5fpTCjQ2Owv0fOKf4Ru/4FMuX0XyVeEKDyBEtKk1O86s5XEX+m+r9vGTxi4K1I4FUq62/pqwxSeNKfoBlWixQUrHOkIn9/xhasDhAFDGOIqyTlOMAyLtpZTYTX1+XNRgFTbVsNHPlmWUsDX1Sg+h2pd5pQAIUU3pfbzOZI0bjYfSB40VOJCnvffU4PozonTa1rjEB7X1zFHIR1Xvn8Mka/MdbPYzgEmDrhFrXCUsznhhIp4GreYisAIYIo0qLxBhZY/YjPjQJA/3Cc2+xU86cyUp8TRFnnQjhfyq8H24S++Delx+X4H39/vmu87/YVgo=
 before_install:
   - git clone https://github.com/standardhealth/shr_spec.git
+  - git --git-dir ./shr_spec checkout dev6
 script:
   - node . shr_spec/spec/

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ $ node . --help
     -l, --log-level <level>  the console log level <fatal,error,warn,info,debug,trace> (default: info)
     -m, --log-mode <mode>    the console log mode <short,long,json,off> (default: short)
     -s, --skip <feature>     skip an export feature <fhir,json,cimcore,json-schema,es6,model-doc,all> (default: <none>)
-    -a, --adl                run the adl exporter (default: false)
     -o, --out <out>          the path to the output folder (default: out)
     -c, --config <config>    the name of the config file (default: config.json)
     -d, --duplicate          show duplicate error messages (default: false)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ $ node . --help
     -c, --config <config>    the name of the config file (default: config.json)
     -d, --duplicate          show duplicate error messages (default: false)
     -i, --import-cimcore     import CIMCORE files instead of CIMPL (default: false)
-    -6, --export-cimpl-6     export CIMPL 6 files generated  from input (default: false)
     -h, --help               output usage information
 ```
 
@@ -233,40 +232,6 @@ Namespace: oncocore
         DateOfDiagnosis MS
     // ... more ...
 ```
-
-# Comment Preservation
-
-When running the CIMPL 6.0 exporter, comments from the CIMPL 5 files are not preserved in the resulting
-exported CIMPL 6.0 files. Thus, in order to try and best preserve the comments, the Python 3 script commentReintegration.py
-can be run from the command line and it will take in the directory where the CIMPL 5 files with comments are held
-and the directory where the exported CIMPL 6.0 files are present. It will then in a new directory called CommentReintegration,
-place the commented CIMPL 6.0 files. One thing to note is that the program assumes that comments will be before a particular line. In addition, for multi-line comments which utilize the /* \*/ notation,
-the parser assumes that no multiline comment begins in the same line as text that may pertain to an Element. Thus, for example this is not valid for the parser:
-```
-Element: A /* This will not be
-preserved */
-```
-
-In addition, no new text should come within the same line as the \*/ symbol. Thus,
-
-```
-/* This will also not be
-preserved */ Element: B
-```
-
-
-Note: When specifying the directory, after specifying the last part of the path, be sure to include a / at the end.
-Example: If your input directory is the spec folder in the shr_spec directory, then you should give something like:
-../shr_spec/spec/
-The same holds for the directory of exported CIMPL 6.0 files. Make sure to include a slash at the end of the path.
-
-
-This is how you can run the script.
-```
-python3 commentReintegration.py [Directory of CIMPL 5 Files] [Directory of Exported CIMPL 6.0 files]
-```
-
-After running this command, the CIMPL6 files with inserted comments will be available in the `CommentReintegration` folder at the root of the shr-cli project.
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The Standard Health Record (SHR) initiative is working to create a single, high-quality health record for every individual in the United States.  For more information, see [standardhealthrecord.org](http://standardhealthrecord.org/).
 
-This GitHub repository contains a Node.js command-line interface for parsing SHR text definitions and exporting them as FHIR profiles, [CIMCORE](https://github.com/standardhealth/shr-cli/wiki/CIMCORE-Documentation) JSON serialized files, JSON schema, ES6 classes, or a JSON document (for website generation).  Future versions of the CLI may support additional capabilities.
+This GitHub repository contains a Node.js command-line interface for parsing SHR text definitions and exporting them as a FHIR IG, [CIMCORE](https://github.com/standardhealth/shr-cli/wiki/CIMCORE-Documentation) JSON serialized files, JSON schema, or ES6 classes.  Future versions of the CLI may support additional capabilities.
 
 The SHR text definitions and grammar files can be found in the [shr_spec](https://github.com/standardhealth/shr_spec) repo.  As the SHR text format (and content files) are still evolving, so is this toolset.
 
@@ -18,9 +18,9 @@ To run the command-line interface, you must perform the following steps to insta
 2. Install [Yarn](https://yarnpkg.com/en/docs/install) (1.3.x or above)
 3. Execute the following from this project's root directory: `yarn`
 
-# Exporting SHR to JSON and FHIR
+# Exporting SHR
 
-After setting up the environment, you can use node to import a folder of files from CAMEO (SHR text format) and export the definitions to JSON and FHIR:
+After setting up the environment, you can use node to import a folder of files from CIMPL (SHR text format) and export the definitions to other formats:
 ```
 $ node . /path/to/shr_spec/spec
 ```
@@ -37,7 +37,7 @@ $ node . --help
 
     -l, --log-level <level>  the console log level <fatal,error,warn,info,debug,trace> (default: info)
     -m, --log-mode <mode>    the console log mode <short,long,json,off> (default: short)
-    -s, --skip <feature>     skip an export feature <fhir,json,cimcore,json-schema,es6,model-doc,all> (default: <none>)
+    -s, --skip <feature>     skip an export feature <fhir,cimcore,json-schema,es6,model-doc,all> (default: <none>)
     -o, --out <out>          the path to the output folder (default: out)
     -c, --config <config>    the name of the config file (default: config.json)
     -d, --duplicate          show duplicate error messages (default: false)
@@ -104,7 +104,7 @@ When using this command-line interface and IG publisher, the general order of op
 
 1. The command-line interface (CLI) imports SHR definitions that have been written (as in the [shr_spec](https://github.com/standardhealth/shr_spec) repo) and parses them through a text importer.
 2. CLI applies filters, according to the `filterStrategy` (see below).
-3. CLI exports the filtered SHR definitions into desired formats, such as ES6, JSON, FHIR, etc. The exports can be selected through command line options, as explained above.
+3. CLI exports the filtered SHR definitions into desired formats, such as FHIR, ES6, etc. The exports can be selected through command line options, as explained above.
 4. (separate, optional step) The IG publisher takes the SHR FHIR export and generates an IG from the information in these files, following the `implementationGuide` configuration (see below).
 
 To control this process, CLI requires a configuration file. Configuration files *must* be valid JSON, have at least the `projectName` property, and use the `.json` file extension. The configuration file must be located in the path to the SHR specification definitions.

--- a/app.js
+++ b/app.js
@@ -39,7 +39,6 @@ program
   .option('-c, --config <config>', 'the name of the config file', 'config.json')
   .option('-d, --duplicate', 'show duplicate error messages (default: false)')
   .option('-i, --import-cimcore', 'import CIMCORE files instead of CIMPL (default: false)')
-  .option('-6, --export-cimpl-6', 'export CIMPL 6 files generated  from input (default: false)')
   .arguments('<path-to-shr-defs>')
   .action(function (pathToShrDefs) {
     input = pathToShrDefs;
@@ -61,9 +60,6 @@ const doCIMCORE = program.skip.every(a => a.toLowerCase() != 'cimcore' && a.toLo
 
 // Process the ADL flag
 const doADL = program.adl;
-
-// Process the CIMPL 6 export flag
-const doCIMPL6 = program.exportCimpl6;
 
 // Process the de-duplicate error flag
 
@@ -278,18 +274,6 @@ if (doJSON) {
 } else {
   logger.info('Skipping JSON export');
 }
-
-if (doCIMPL6) {
-  logger.info('Exporting CIMPL 6');
-  try {
-    const cimpl6Path = path.join(program.out, 'cimpl6');
-    expSpecifications.toCIMPL6(cimpl6Path);
-    logger.info('Exported %s namespaces to CIMPL 6.', expSpecifications.namespaces.all.length);
-  } catch (error) {
-    logger.fatal('Failure in CIMPL 6 export. Aborting with error message: %s', error);
-    failedExports.push('cimpl-6-export');
-  }
-} // the CIMPL 6 export is opt-in, so we are omitting the 'skip' info log.
 
 let fhirResults = null;
 if (doES6 || doFHIR){

--- a/app.js
+++ b/app.js
@@ -9,7 +9,7 @@ const shrTI = require('shr-text-import');
 const shrEx = require('shr-expand');
 const shrJE = require('shr-json-export');
 const shrJSE = require('shr-json-schema-export');
-const shrEE = require('shr-es6-export');
+// const shrEE = require('shr-es6-export');
 const shrFE = require('shr-fhir-export');
 const shrJDE = require('shr-json-javadoc');
 const shrAE = require('shr-adl-bmm-export');
@@ -18,7 +18,7 @@ const SpecificationsFilter = require('./filter');
 
 /* eslint-disable no-console */
 
-sanityCheckModules({shrTI, shrEx, shrJE, shrJSE, shrEE, shrFE });
+sanityCheckModules({shrTI, shrEx, shrJE, shrJSE, /*shrEE,*/ shrFE });
 
 // Record the time so we can print elapsed time
 const hrstart = process.hrtime();
@@ -111,7 +111,7 @@ if (doADL) {
   shrAE.setLogger(logger.child({module: 'shr-adl-export'}));
 }
 if (doES6) {
-  shrEE.setLogger(logger.child({ module: 'shr-es6-export'}));
+  //shrEE.setLogger(logger.child({ module: 'shr-es6-export'}));
 }
 
 // Go!
@@ -297,24 +297,25 @@ if (doES6 || doFHIR){
 }
 
 if (doES6) {
-  try {
-    const es6Results = shrEE.exportToES6(expSpecifications, fhirResults);
-    const es6Path = path.join(program.out, 'es6');
-    const handleNS = (obj, fpath) => {
-      mkdirp.sync(fpath);
-      for (const key of Object.keys(obj)) {
-        if (key.endsWith('.js')) {
-          fs.writeFileSync(path.join(fpath, key), obj[key]);
-        } else {
-          handleNS(obj[key], path.join(fpath, key));
-        }
-      }
-    };
-    handleNS(es6Results, es6Path);
-  } catch (error) {
-    logger.fatal('Failure in ES6 export. Aborting with error message: %s', error);
-    failedExports.push('shr-es6-export');
-  }
+  logger.info('ES6 export disabled in SHR CLI 6.0.0-beta.1.  Will be re-enabled in a future beta.');
+  // try {
+  //   const es6Results = shrEE.exportToES6(expSpecifications, fhirResults);
+  //   const es6Path = path.join(program.out, 'es6');
+  //   const handleNS = (obj, fpath) => {
+  //     mkdirp.sync(fpath);
+  //     for (const key of Object.keys(obj)) {
+  //       if (key.endsWith('.js')) {
+  //         fs.writeFileSync(path.join(fpath, key), obj[key]);
+  //       } else {
+  //         handleNS(obj[key], path.join(fpath, key));
+  //       }
+  //     }
+  //   };
+  //   handleNS(es6Results, es6Path);
+  // } catch (error) {
+  //   logger.fatal('Failure in ES6 export. Aborting with error message: %s', error);
+  //   failedExports.push('shr-es6-export');
+  // }
 } else {
   logger.info('Skipping ES6 export');
 }

--- a/app.js
+++ b/app.js
@@ -12,7 +12,6 @@ const shrJSE = require('shr-json-schema-export');
 const shrEE = require('shr-es6-export');
 const shrFE = require('shr-fhir-export');
 const shrJDE = require('shr-json-javadoc');
-const shrAE = require('shr-adl-bmm-export');
 const LogCounter = require('./logcounter');
 const SpecificationsFilter = require('./filter');
 
@@ -34,7 +33,6 @@ program
   .option('-l, --log-level <level>', 'the console log level <fatal,error,warn,info,debug,trace>', /^(fatal|error|warn|info|debug|trace)$/i, 'info')
   .option('-m, --log-mode <mode>', 'the console log mode <short,long,json,off>', /^(short|long|json|off)$/i, 'short')
   .option('-s, --skip <feature>', 'skip an export feature <fhir,json,cimcore,json-schema,es6,model-doc,all>', collect, [])
-  .option('-a, --adl', 'run the adl exporter (default: false)')
   .option('-o, --out <out>', `the path to the output folder`, path.join('.', 'out'))
   .option('-c, --config <config>', 'the name of the config file', 'config.json')
   .option('-d, --duplicate', 'show duplicate error messages (default: false)')
@@ -57,9 +55,6 @@ const doJSONSchema = program.skip.every(a => a.toLowerCase() != 'json-schema' &&
 const doES6 = program.skip.every(a => a.toLowerCase() != 'es6' && a.toLowerCase() != 'all');
 const doModelDoc = program.skip.every(a => a.toLowerCase() != 'model-doc' && a.toLowerCase() != 'all');
 const doCIMCORE = program.skip.every(a => a.toLowerCase() != 'cimcore' && a.toLowerCase() != 'all');
-
-// Process the ADL flag
-const doADL = program.adl;
 
 // Process the de-duplicate error flag
 
@@ -102,9 +97,6 @@ if (doJSONSchema) {
 }
 if (doModelDoc) {
   shrJDE.setLogger(logger.child({ module: 'shr-json-javadoc' }));
-}
-if (doADL) {
-  shrAE.setLogger(logger.child({module: 'shr-adl-export'}));
 }
 if (doES6) {
   shrEE.setLogger(logger.child({ module: 'shr-es6-export'}));
@@ -243,17 +235,6 @@ if (doCIMCORE) {
   }
 } else {
   logger.info('Skipping CIMCORE export');
-}
-
-if (doADL) {
-  try {
-    shrAE.generateADLtoPath(expSpecifications, configSpecifications, program.out);
-  } catch (error) {
-    logger.fatal('Failure in ADL export. Aborting with error message: %s', error);
-    failedExports.push('shr-adl-bmm-export');
-  }
-} else {
-  logger.info('Skipping ADL export');
 }
 
 if (doJSON) {

--- a/app.js
+++ b/app.js
@@ -9,7 +9,7 @@ const shrTI = require('shr-text-import');
 const shrEx = require('shr-expand');
 const shrJE = require('shr-json-export');
 const shrJSE = require('shr-json-schema-export');
-// const shrEE = require('shr-es6-export');
+const shrEE = require('shr-es6-export');
 const shrFE = require('shr-fhir-export');
 const shrJDE = require('shr-json-javadoc');
 const shrAE = require('shr-adl-bmm-export');
@@ -18,7 +18,7 @@ const SpecificationsFilter = require('./filter');
 
 /* eslint-disable no-console */
 
-sanityCheckModules({shrTI, shrEx, shrJE, shrJSE, /*shrEE,*/ shrFE });
+sanityCheckModules({shrTI, shrEx, shrJE, shrJSE, shrEE, shrFE });
 
 // Record the time so we can print elapsed time
 const hrstart = process.hrtime();
@@ -111,7 +111,7 @@ if (doADL) {
   shrAE.setLogger(logger.child({module: 'shr-adl-export'}));
 }
 if (doES6) {
-  //shrEE.setLogger(logger.child({ module: 'shr-es6-export'}));
+  shrEE.setLogger(logger.child({ module: 'shr-es6-export'}));
 }
 
 // Go!
@@ -297,25 +297,24 @@ if (doES6 || doFHIR){
 }
 
 if (doES6) {
-  logger.info('ES6 export disabled in SHR CLI 6.0.0-beta.1.  Will be re-enabled in a future beta.');
-  // try {
-  //   const es6Results = shrEE.exportToES6(expSpecifications, fhirResults);
-  //   const es6Path = path.join(program.out, 'es6');
-  //   const handleNS = (obj, fpath) => {
-  //     mkdirp.sync(fpath);
-  //     for (const key of Object.keys(obj)) {
-  //       if (key.endsWith('.js')) {
-  //         fs.writeFileSync(path.join(fpath, key), obj[key]);
-  //       } else {
-  //         handleNS(obj[key], path.join(fpath, key));
-  //       }
-  //     }
-  //   };
-  //   handleNS(es6Results, es6Path);
-  // } catch (error) {
-  //   logger.fatal('Failure in ES6 export. Aborting with error message: %s', error);
-  //   failedExports.push('shr-es6-export');
-  // }
+  try {
+    const es6Results = shrEE.exportToES6(expSpecifications, fhirResults);
+    const es6Path = path.join(program.out, 'es6');
+    const handleNS = (obj, fpath) => {
+      mkdirp.sync(fpath);
+      for (const key of Object.keys(obj)) {
+        if (key.endsWith('.js')) {
+          fs.writeFileSync(path.join(fpath, key), obj[key]);
+        } else {
+          handleNS(obj[key], path.join(fpath, key));
+        }
+      }
+    };
+    handleNS(es6Results, es6Path);
+  } catch (error) {
+    logger.fatal('Failure in ES6 export. Aborting with error message: %s', error);
+    failedExports.push('shr-es6-export');
+  }
 } else {
   logger.info('Skipping ES6 export');
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "commander": "^2.9.0",
     "fs-extra": "^7.0.0",
     "mkdirp": "^0.5.1",
-    "shr-adl-bmm-export": "^1.0.1",
     "shr-es6-export": "^6.0.0-beta.1",
     "shr-expand": "^6.0.0-beta.1",
     "shr-fhir-export": "^6.0.0-beta.1",

--- a/package.json
+++ b/package.json
@@ -23,11 +23,12 @@
     "fs-extra": "^7.0.0",
     "mkdirp": "^0.5.1",
     "shr-adl-bmm-export": "^1.0.1",
+    "shr-es6-export": "^6.0.0-beta.1",
     "shr-expand": "^6.0.0-beta.1",
     "shr-fhir-export": "^6.0.0-beta.1",
     "shr-json-export": "^6.0.0-beta.1",
     "shr-json-javadoc": "^6.0.0-beta.1",
-    "shr-json-schema-export": "^6.0.0-beta.1",
+    "shr-json-schema-export": "^6.0.0-beta.2",
     "shr-models": "^6.0.0-beta.1",
     "shr-text-import": "^6.0.0-beta.1"
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "shr-es6-export": "^6.0.0-beta.1",
     "shr-expand": "^6.0.0-beta.1",
     "shr-fhir-export": "^6.0.0-beta.1",
-    "shr-json-export": "^6.0.0-beta.1",
     "shr-json-javadoc": "^6.0.0-beta.1",
     "shr-json-schema-export": "^6.0.0-beta.2",
     "shr-models": "^6.0.0-beta.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-cli",
-  "version": "6.0.0-beta.2",
+  "version": "6.0.0",
   "description": "Command-line interface for SHR tools",
   "author": "",
   "license": "Apache-2.0",
@@ -22,13 +22,13 @@
     "commander": "^2.9.0",
     "fs-extra": "^7.0.0",
     "mkdirp": "^0.5.1",
-    "shr-es6-export": "^6.0.0-beta.2",
-    "shr-expand": "^6.0.0-beta.2",
-    "shr-fhir-export": "^6.0.0-beta.2",
-    "shr-json-javadoc": "^6.0.0-beta.1",
-    "shr-json-schema-export": "^6.0.0-beta.3",
-    "shr-models": "^6.0.0-beta.2",
-    "shr-text-import": "^6.0.0-beta.2"
+    "shr-es6-export": "^6.0.0",
+    "shr-expand": "^6.0.0",
+    "shr-fhir-export": "^6.0.0",
+    "shr-json-javadoc": "^6.0.0",
+    "shr-json-schema-export": "^6.0.0",
+    "shr-models": "^6.0.0",
+    "shr-text-import": "^6.0.0"
   },
   "devDependencies": {
     "eslint": "^4.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-cli",
-  "version": "6.0.0-beta.1",
+  "version": "6.0.0-beta.2",
   "description": "Command-line interface for SHR tools",
   "author": "",
   "license": "Apache-2.0",
@@ -22,13 +22,13 @@
     "commander": "^2.9.0",
     "fs-extra": "^7.0.0",
     "mkdirp": "^0.5.1",
-    "shr-es6-export": "^6.0.0-beta.1",
-    "shr-expand": "^6.0.0-beta.1",
-    "shr-fhir-export": "^6.0.0-beta.1",
+    "shr-es6-export": "^6.0.0-beta.2",
+    "shr-expand": "^6.0.0-beta.2",
+    "shr-fhir-export": "^6.0.0-beta.2",
     "shr-json-javadoc": "^6.0.0-beta.1",
-    "shr-json-schema-export": "^6.0.0-beta.2",
-    "shr-models": "^6.0.0-beta.1",
-    "shr-text-import": "^6.0.0-beta.1"
+    "shr-json-schema-export": "^6.0.0-beta.3",
+    "shr-models": "^6.0.0-beta.2",
+    "shr-text-import": "^6.0.0-beta.2"
   },
   "devDependencies": {
     "eslint": "^4.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-cli",
-  "version": "5.19.0",
+  "version": "6.0.0-beta.1",
   "description": "Command-line interface for SHR tools",
   "author": "",
   "license": "Apache-2.0",
@@ -23,14 +23,13 @@
     "fs-extra": "^7.0.0",
     "mkdirp": "^0.5.1",
     "shr-adl-bmm-export": "^1.0.1",
-    "shr-es6-export": "^5.7.2",
-    "shr-expand": "^5.8.1",
-    "shr-fhir-export": "^5.14.0",
-    "shr-json-export": "^5.1.5",
-    "shr-json-javadoc": "^1.4.5",
-    "shr-json-schema-export": "^5.3.2",
-    "shr-models": "^5.9.0",
-    "shr-text-import": "^5.7.1"
+    "shr-expand": "^6.0.0-beta.1",
+    "shr-fhir-export": "^6.0.0-beta.1",
+    "shr-json-export": "^6.0.0-beta.1",
+    "shr-json-javadoc": "^6.0.0-beta.1",
+    "shr-json-schema-export": "^6.0.0-beta.1",
+    "shr-models": "^6.0.0-beta.1",
+    "shr-text-import": "^6.0.0-beta.1"
   },
   "devDependencies": {
     "eslint": "^4.6.1",

--- a/pull-all
+++ b/pull-all
@@ -20,10 +20,6 @@ cd ../shr-text-import
 echo "================= shr-text-import =================="
 git pull
 
-cd ../shr-json-export
-echo "================= shr-json-export =================="
-git pull
-
 cd ../shr-json-schema-export
 echo "============== shr-json-schema-export =============="
 git pull

--- a/pull-all
+++ b/pull-all
@@ -40,10 +40,6 @@ cd ../shr-fhir-export
 echo "================= shr-fhir-export =================="
 git pull
 
-cd ../shr-adl-bmm-export
-echo "================= shr-adl-bmm-export =================="
-git pull
-
 cd ../shr-cli
 echo "===================== shr-cli ======================"
 git pull

--- a/rebuild-all
+++ b/rebuild-all
@@ -45,11 +45,6 @@ echo "================= shr-fhir-export =================="
 rm -rf node_modules
 yarn
 
-cd ../shr-adl-bmm-export
-echo "================= shr-adl-bmm-export =================="
-rm -rf node_modules
-yarn
-
 cd ../shr-cli
 echo "===================== shr-cli ======================"
 rm -rf node_modules

--- a/rebuild-all
+++ b/rebuild-all
@@ -20,11 +20,6 @@ echo "================= shr-text-import =================="
 rm -rf node_modules
 yarn
 
-cd ../shr-json-export
-echo "================= shr-json-export =================="
-rm -rf node_modules
-yarn
-
 cd ../shr-json-schema-export
 echo "============== shr-json-schema-export =============="
 rm -rf node_modules

--- a/yarn-link-all
+++ b/yarn-link-all
@@ -18,6 +18,7 @@ yarn link
 cd ../shr-text-import
 echo "================= shr-text-import =================="
 yarn link shr-models
+yarn link shr-expand
 yarn link shr-test-helpers
 yarn link
 

--- a/yarn-link-all
+++ b/yarn-link-all
@@ -22,12 +22,6 @@ yarn link shr-expand
 yarn link shr-test-helpers
 yarn link
 
-cd ../shr-json-export
-echo "================= shr-json-export =================="
-yarn link shr-models
-yarn link shr-test-helpers
-yarn link
-
 cd ../shr-json-schema-export
 echo "============== shr-json-schema-export =============="
 yarn link shr-models
@@ -60,7 +54,6 @@ echo "===================== shr-cli ======================"
 yarn link shr-models
 yarn link shr-expand
 yarn link shr-text-import
-yarn link shr-json-export
 yarn link shr-json-schema-export
 yarn link shr-json-javadoc
 yarn link shr-es6-export

--- a/yarn-link-all
+++ b/yarn-link-all
@@ -55,10 +55,6 @@ yarn link shr-test-helpers
 yarn link shr-fhir-export
 yarn link
 
-cd ../shr-adl-bmm-export
-echo "=============== shr-adl-bmm-export ================="
-yarn link
-
 cd ../shr-cli
 echo "===================== shr-cli ======================"
 yarn link shr-models
@@ -69,4 +65,3 @@ yarn link shr-json-schema-export
 yarn link shr-json-javadoc
 yarn link shr-es6-export
 yarn link shr-fhir-export
-yarn link shr-adl-bmm-export

--- a/yarn-unlink-all
+++ b/yarn-unlink-all
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 echo "===================== shr-cli ======================"
-yarn unlink shr-adl-bmm-export
 yarn unlink shr-fhir-export
 yarn unlink shr-es6-export
 yarn unlink shr-json-schema-export
@@ -10,10 +9,6 @@ yarn unlink shr-json-javadoc
 yarn unlink shr-text-import
 yarn unlink shr-expand
 yarn unlink shr-models
-
-cd ../shr-adl-bmm-export
-echo "=============== shr-adl-bmm-export ================="
-yarn unlink
 
 cd ../shr-es6-export
 echo "================== shr-es6-export =================="

--- a/yarn-unlink-all
+++ b/yarn-unlink-all
@@ -51,6 +51,7 @@ yarn unlink
 cd ../shr-text-import
 echo "================= shr-text-import =================="
 yarn unlink shr-models
+yarn unlink shr-expand
 yarn unlink shr-test-helpers
 yarn unlink
 

--- a/yarn-unlink-all
+++ b/yarn-unlink-all
@@ -4,7 +4,6 @@ echo "===================== shr-cli ======================"
 yarn unlink shr-fhir-export
 yarn unlink shr-es6-export
 yarn unlink shr-json-schema-export
-yarn unlink shr-json-export
 yarn unlink shr-json-javadoc
 yarn unlink shr-text-import
 yarn unlink shr-expand
@@ -35,12 +34,6 @@ yarn unlink
 
 cd ../shr-json-javadoc
 echo "============== shr-json-javadoc ===================="
-yarn unlink
-
-cd ../shr-json-export
-echo "================= shr-json-export =================="
-yarn unlink shr-models
-yarn unlink shr-test-helpers
 yarn unlink
 
 cd ../shr-text-import

--- a/yarn.lock
+++ b/yarn.lock
@@ -874,6 +874,11 @@ require-uncached@^1.0.3:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
 
+reserved-words@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/reserved-words/-/reserved-words-0.1.2.tgz#00a0940f98cd501aeaaac316411d9adc52b31ab1"
+  integrity sha1-AKCUD5jNUBrqqsMWQR2a3FKzGrE=
+
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
@@ -947,6 +952,13 @@ shr-adl-bmm-export@^1.0.1:
     dedent-js "^1.0.1"
     eslint "^4.19.1"
 
+shr-es6-export@^6.0.0-beta.1:
+  version "6.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/shr-es6-export/-/shr-es6-export-6.0.0-beta.1.tgz#81e4bf410bcd9508e8654e245ac097976ed29223"
+  integrity sha512-hofsmo16T18AwOOX8lrqT0MOgQJLqSND3QVaCNDhzSSOJ0uGD5WMn91vMsr/Jf4c6LmWREycNOCUa3yTldjwtQ==
+  dependencies:
+    reserved-words "^0.1.2"
+
 shr-expand@^6.0.0-beta.1:
   version "6.0.0-beta.1"
   resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-6.0.0-beta.1.tgz#2ef7ada2c5d5cc390e05216ebba88a160bb3c924"
@@ -975,10 +987,10 @@ shr-json-javadoc@^6.0.0-beta.1:
     ncp "^2.0.0"
     showdown "^1.8.6"
 
-shr-json-schema-export@^6.0.0-beta.1:
-  version "6.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/shr-json-schema-export/-/shr-json-schema-export-6.0.0-beta.1.tgz#a975f737556eb32bb55bd4a0b7ef522816bcc6a7"
-  integrity sha512-Yzvp4l78d4CoMMTeI1z183Fx+PErjhTEEUKpmFBU7huzH6Pfa/6HhgIeYAngTsfZ2+D9rA4zyPGyZiHh/P9SfA==
+shr-json-schema-export@^6.0.0-beta.2:
+  version "6.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/shr-json-schema-export/-/shr-json-schema-export-6.0.0-beta.2.tgz#aaff08a41ba5c161c160bcce13ce9aa91943cf77"
+  integrity sha512-Z5nJJ9qmR1xkrJMo+gIoWxyLz6fUcBXPfUQTVQYmw68tRy9Bg9MB/JJdfXsoPfa+fDnQJaz8bL0J+U5aKnCrwQ==
 
 shr-models@^6.0.0-beta.1:
   version "6.0.0-beta.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -960,11 +960,6 @@ shr-fhir-export@^6.0.0-beta.1:
     fs-extra "^2.0.0"
     lodash "^4.17.5"
 
-shr-json-export@^6.0.0-beta.1:
-  version "6.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/shr-json-export/-/shr-json-export-6.0.0-beta.1.tgz#0aac5fd5133376dd48b38e0c8ea47c07944d1af0"
-  integrity sha512-xPRuqIUO0HXWKOAVukoc74HPdPxywKuW29VuaQVz2rcUhMskcWI8cBjvKxbDY+H71IT4gXwZCaqr27G31KWYLw==
-
 shr-json-javadoc@^6.0.0-beta.1:
   version "6.0.0-beta.1"
   resolved "https://registry.yarnpkg.com/shr-json-javadoc/-/shr-json-javadoc-6.0.0-beta.1.tgz#5f06dd46288f13041b1e5939f4db36b23c548400"

--- a/yarn.lock
+++ b/yarn.lock
@@ -928,50 +928,50 @@ showdown@^1.8.6:
   dependencies:
     yargs "^10.0.3"
 
-shr-es6-export@^6.0.0-beta.2:
-  version "6.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/shr-es6-export/-/shr-es6-export-6.0.0-beta.2.tgz#8314b61c58e19d19fd4881871f4f59f3350473d1"
-  integrity sha512-YKPcgn6877IEb6JjcotrxIingBe/acyz9n4e3KL84OKZXE2x9nRcwa5A2LxY0KZG0OIgEc3uXDz4QrGS2tOKTw==
+shr-es6-export@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/shr-es6-export/-/shr-es6-export-6.0.0.tgz#c8a0c60a01e53d90518296fffbbc997f45ff8369"
+  integrity sha512-EXz0jQd+pzzM5oWRtel9x3/cfJsRPQdpcDp6nqvNvfWgPqtceRGThbHnJW1kdxWTNFIp35hQIfYb6N7u/gO1Mg==
   dependencies:
     reserved-words "^0.1.2"
 
-shr-expand@^6.0.0-beta.2:
-  version "6.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-6.0.0-beta.2.tgz#030b6d6c72071b1ca8e171863ad7466b4bd02aab"
-  integrity sha512-XBMSJcg7aeCV0OjNrARDhnYUZ0FInojpNKfjKjBb42lMP4pmEuifY/ErSzXDauJLzUZpV3BuRXQ5XueKau9p3Q==
+shr-expand@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-6.0.0.tgz#a2072f971e19b9f221e012c0056ee389a78633d7"
+  integrity sha512-zzjli5uVY23J4jHnr5Cr+iLkZ7+6RsHk3kQMksBPUR4ly96NXlCRgillJ3IszbdP3dHpBuWymcrAOjyz4C/lRA==
 
-shr-fhir-export@^6.0.0-beta.2:
-  version "6.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-6.0.0-beta.2.tgz#c75fbb78527c1a1a71fcfb7565090bcdc65f601c"
-  integrity sha512-0pynFO3WVUQ0L5oN9CGTtcvzeZHYyZF66MXz2ZqW8uukHlGoM2AtyxftCXLNWyXpsoTOKiiYnXisUS6cRYzKMg==
+shr-fhir-export@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-6.0.0.tgz#61cd6e1b08721514950f293a53fbd162f93e236c"
+  integrity sha512-ZNFnkxOvb26Rq2lIvXsuVSnoPfZsVsCgim7BrytqiNUK0jUXnvSa8oOomXYAILVKb631AK3KCMr3ZQ47ZvKcIQ==
   dependencies:
     fs-extra "^2.0.0"
     lodash "^4.17.5"
 
-shr-json-javadoc@^6.0.0-beta.1:
-  version "6.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/shr-json-javadoc/-/shr-json-javadoc-6.0.0-beta.1.tgz#5f06dd46288f13041b1e5939f4db36b23c548400"
-  integrity sha512-r1YKKYWY4sfxymkZnvZNjIc4sIHbfM5b4Reiw1Y+VQZ7x0SwlqMkVz/Bgomj1Uoyt0uofmVxJaVoKAlY/aaS3g==
+shr-json-javadoc@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/shr-json-javadoc/-/shr-json-javadoc-6.0.0.tgz#fd4ef1168f14764ad04b610ff5e2e8034813a935"
+  integrity sha512-lpCz6sD0HaFbkL4HrzAw1puglvjzc8ZXLgT1O1v/ibkXh4gVLKy2BdL8exPFT7pyMTg705sYRN+5zJrt7hN0+g==
   dependencies:
     bluebird "^3.5.1"
     ejs "^2.5.7"
     ncp "^2.0.0"
     showdown "^1.8.6"
 
-shr-json-schema-export@^6.0.0-beta.3:
-  version "6.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/shr-json-schema-export/-/shr-json-schema-export-6.0.0-beta.3.tgz#699b4fcd00170036db2c4292908aae24d64ad33d"
-  integrity sha512-0AWmKusiSaADIcY5z3honxbWsfk7xK39iyZ5fmX/KTCuO+8nGmVFLqCB+jBd2wMKoJZmPS1O/HpwZlO+p5G1ig==
+shr-json-schema-export@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/shr-json-schema-export/-/shr-json-schema-export-6.0.0.tgz#08e969c5debf5719b298c59c2b1ef83f1c52fa3e"
+  integrity sha512-megbVDNpi/PenTVFHFbkqgAmud8LwToveyUaKL0qabnEJ1QzwUuik3aZFz007kC7iidyAVKGo0GcKUBb0k1RQg==
 
-shr-models@^6.0.0-beta.2:
-  version "6.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-6.0.0-beta.2.tgz#8a730e43dc3e044e26758d7e7569155207901215"
-  integrity sha512-8VpMawL//uZ5dhXoNCEfVmxBAoPhPtLHdvLDwdedujaFdggqNOKwncn8KsYbJl3FXrnwWKlG8FOMRkEYw9xXBg==
+shr-models@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-6.0.0.tgz#6ffe6a48ae6bcf6c20e25dbfcc5b2954fca7d661"
+  integrity sha512-k8tU/YghNoFdpHxzC1ZpfpHMEMAJPZyGGAMd9QfOcCqDsETUyK9u76GuXoSlhXHjDM5CXOCeq6LmxWCQhK95iw==
 
-shr-text-import@^6.0.0-beta.2:
-  version "6.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/shr-text-import/-/shr-text-import-6.0.0-beta.2.tgz#865779066ec389f7c66a4213db870debcc7fd244"
-  integrity sha512-zCcqdyGTO6mqUCwpEnITFaCH5g2MTZiY/BtsoSMG/JBPqxw7duVwYsABFDdwQCI/Hv7k2q51kBLy0RfVgO1tLg==
+shr-text-import@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/shr-text-import/-/shr-text-import-6.0.0.tgz#79aea057d8be13571ea9c4c833172268f52e85a8"
+  integrity sha512-6OhJaV/3cr8eMaQ6fm7YtDM94tEHAJoq9O43/Neulq0JPAPOrzbSkdgUTryM3TzMH3Eaup93EwvBhKwla9xsqQ==
   dependencies:
     antlr4 "~4.6.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -256,6 +256,13 @@ doctrine@^2.1.0:
   dependencies:
     esutils "^2.0.2"
 
+dtrace-provider@^0.8.7:
+  version "0.8.7"
+  resolved "https://registry.yarnpkg.com/dtrace-provider/-/dtrace-provider-0.8.7.tgz#dc939b4d3e0620cfe0c1cd803d0d2d7ed04ffd04"
+  integrity sha1-3JObTT4GIM/gwc2APQ0tftBP/QQ=
+  dependencies:
+    nan "^2.10.0"
+
 dtrace-provider@~0.8:
   version "0.8.6"
   resolved "https://registry.yarnpkg.com/dtrace-provider/-/dtrace-provider-0.8.6.tgz#428a223afe03425d2cd6d6347fdf40c66903563d"
@@ -696,6 +703,11 @@ mv@~2:
     ncp "~2.0.0"
     rimraf "~2.4.0"
 
+nan@^2.10.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
+  integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
+
 nan@^2.3.3:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
@@ -862,10 +874,6 @@ require-uncached@^1.0.3:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
 
-reserved-words@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/reserved-words/-/reserved-words-0.1.2.tgz#00a0940f98cd501aeaaac316411d9adc52b31ab1"
-
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
@@ -939,51 +947,51 @@ shr-adl-bmm-export@^1.0.1:
     dedent-js "^1.0.1"
     eslint "^4.19.1"
 
-shr-es6-export@^5.7.2:
-  version "5.7.2"
-  resolved "https://registry.yarnpkg.com/shr-es6-export/-/shr-es6-export-5.7.2.tgz#addebc6c3a1b0c6d7c73ed86ebe2e8c5ae07426d"
-  integrity sha512-ydAyAbYKKdUd9J7j4s1AMevykTJwy7C957Wc5pv37PugXTFrKrhNCU+ifBEZx9vxa6zIVYV/fgzoK6rm2whMaQ==
-  dependencies:
-    reserved-words "^0.1.2"
+shr-expand@^6.0.0-beta.1:
+  version "6.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-6.0.0-beta.1.tgz#2ef7ada2c5d5cc390e05216ebba88a160bb3c924"
+  integrity sha512-CQ2zOMQ3cD/8g0F89KfZGNoARzie7fEK4CfCM6Xd8RWMFAIK26gAJN5+M5yqEqghxCqt9RFvQP/WnmBL2mopgA==
 
-shr-expand@^5.8.1:
-  version "5.8.1"
-  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.8.1.tgz#99aa50b7c9d8dfbe7d2c996740b8770e3d23527c"
-
-shr-fhir-export@^5.14.0:
-  version "5.14.0"
-  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.14.0.tgz#1217931ebfb736059f2b5c4c9e943a932881ae54"
+shr-fhir-export@^6.0.0-beta.1:
+  version "6.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-6.0.0-beta.1.tgz#0d1f0190060119940eabc822ba5460d1af880a58"
+  integrity sha512-Sy4/F0wTBlZOuw96LroWBKNnc96RLpEMqb7PP9UenKC4vosU1F+euLBpDJz9l13elPGzXPApDh9hlGmdqEL3Jg==
   dependencies:
     fs-extra "^2.0.0"
     lodash "^4.17.5"
 
-shr-json-export@^5.1.5:
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/shr-json-export/-/shr-json-export-5.1.5.tgz#62ee553e1ac18808ff2cea6400ba128a60fafe8a"
+shr-json-export@^6.0.0-beta.1:
+  version "6.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/shr-json-export/-/shr-json-export-6.0.0-beta.1.tgz#0aac5fd5133376dd48b38e0c8ea47c07944d1af0"
+  integrity sha512-xPRuqIUO0HXWKOAVukoc74HPdPxywKuW29VuaQVz2rcUhMskcWI8cBjvKxbDY+H71IT4gXwZCaqr27G31KWYLw==
 
-shr-json-javadoc@^1.4.5:
-  version "1.4.5"
-  resolved "https://registry.yarnpkg.com/shr-json-javadoc/-/shr-json-javadoc-1.4.5.tgz#056895e5d20ab06c4a8d7549953646cb08436038"
+shr-json-javadoc@^6.0.0-beta.1:
+  version "6.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/shr-json-javadoc/-/shr-json-javadoc-6.0.0-beta.1.tgz#5f06dd46288f13041b1e5939f4db36b23c548400"
+  integrity sha512-r1YKKYWY4sfxymkZnvZNjIc4sIHbfM5b4Reiw1Y+VQZ7x0SwlqMkVz/Bgomj1Uoyt0uofmVxJaVoKAlY/aaS3g==
   dependencies:
     bluebird "^3.5.1"
     ejs "^2.5.7"
     ncp "^2.0.0"
     showdown "^1.8.6"
 
-shr-json-schema-export@^5.3.2:
-  version "5.3.2"
-  resolved "https://registry.yarnpkg.com/shr-json-schema-export/-/shr-json-schema-export-5.3.2.tgz#8840b62eb6a882cb242043e93733e1f3bd472a21"
+shr-json-schema-export@^6.0.0-beta.1:
+  version "6.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/shr-json-schema-export/-/shr-json-schema-export-6.0.0-beta.1.tgz#a975f737556eb32bb55bd4a0b7ef522816bcc6a7"
+  integrity sha512-Yzvp4l78d4CoMMTeI1z183Fx+PErjhTEEUKpmFBU7huzH6Pfa/6HhgIeYAngTsfZ2+D9rA4zyPGyZiHh/P9SfA==
 
-shr-models@^5.9.0:
-  version "5.9.0"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.9.0.tgz#579c7e0387688b0d49a54fe18f8431210bd285b7"
-  integrity sha512-pv4wSeVnfP3K6zfhTsVlYcVXlct4iHO/qSwCpbe0YP4XoaZ6ym2BuGP3vX62D+EEZSAPyoaBOL6G7WkVVlu0Qw==
+shr-models@^6.0.0-beta.1:
+  version "6.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-6.0.0-beta.1.tgz#52f6c9ff10838820c00d6c4e524b237fb95db646"
+  integrity sha512-M7Iz17rCDXDnJ+Su2FbybikNT/O2fHG50BkS+rH4ydFa/6EgLvhL89VI+o9qG+mot3DRb+gvMStn9n7SVkqkwQ==
 
-shr-text-import@^5.7.1:
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/shr-text-import/-/shr-text-import-5.7.1.tgz#81d1c54be5eba751a9849e9f368618a3762097b0"
+shr-text-import@^6.0.0-beta.1:
+  version "6.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/shr-text-import/-/shr-text-import-6.0.0-beta.1.tgz#fc0bd420d2ac70fbfe991d6bc7413dffa6219209"
+  integrity sha512-sqXWkxBF7uhbkoiAGVAME6vkINxh7NdJLIW9H+hSqMrs1qiY9dUCqQWTvy/misCHRnXB3A495mgPKcLKIHHXHw==
   dependencies:
     antlr4 "~4.6.0"
+    dtrace-provider "^0.8.7"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -230,10 +230,6 @@ decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
-dedent-js@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/dedent-js/-/dedent-js-1.0.1.tgz#bee5fb7c9e727d85dffa24590d10ec1ab1255305"
-
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
@@ -288,7 +284,7 @@ eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
 
-eslint@^4.19.1, eslint@^4.6.1:
+eslint@^4.6.1:
   version "4.19.1"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.19.1.tgz#32d1d653e1d90408854bfb296f076ec7e186a300"
   dependencies:
@@ -943,14 +939,6 @@ showdown@^1.8.6:
   resolved "https://registry.yarnpkg.com/showdown/-/showdown-1.8.6.tgz#91ea4ee3b7a5448aaca6820a4e27e690c6ad771c"
   dependencies:
     yargs "^10.0.3"
-
-shr-adl-bmm-export@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/shr-adl-bmm-export/-/shr-adl-bmm-export-1.0.1.tgz#e4272bd97dbcf6c387eaeb9a3b7a7c8acbc9a1a3"
-  dependencies:
-    bunyan "^1.8.12"
-    dedent-js "^1.0.1"
-    eslint "^4.19.1"
 
 shr-es6-export@^6.0.0-beta.1:
   version "6.0.0-beta.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -252,13 +252,6 @@ doctrine@^2.1.0:
   dependencies:
     esutils "^2.0.2"
 
-dtrace-provider@^0.8.7:
-  version "0.8.7"
-  resolved "https://registry.yarnpkg.com/dtrace-provider/-/dtrace-provider-0.8.7.tgz#dc939b4d3e0620cfe0c1cd803d0d2d7ed04ffd04"
-  integrity sha1-3JObTT4GIM/gwc2APQ0tftBP/QQ=
-  dependencies:
-    nan "^2.10.0"
-
 dtrace-provider@~0.8:
   version "0.8.6"
   resolved "https://registry.yarnpkg.com/dtrace-provider/-/dtrace-provider-0.8.6.tgz#428a223afe03425d2cd6d6347fdf40c66903563d"
@@ -699,11 +692,6 @@ mv@~2:
     ncp "~2.0.0"
     rimraf "~2.4.0"
 
-nan@^2.10.0:
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
-  integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
-
 nan@^2.3.3:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
@@ -940,22 +928,22 @@ showdown@^1.8.6:
   dependencies:
     yargs "^10.0.3"
 
-shr-es6-export@^6.0.0-beta.1:
-  version "6.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/shr-es6-export/-/shr-es6-export-6.0.0-beta.1.tgz#81e4bf410bcd9508e8654e245ac097976ed29223"
-  integrity sha512-hofsmo16T18AwOOX8lrqT0MOgQJLqSND3QVaCNDhzSSOJ0uGD5WMn91vMsr/Jf4c6LmWREycNOCUa3yTldjwtQ==
+shr-es6-export@^6.0.0-beta.2:
+  version "6.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/shr-es6-export/-/shr-es6-export-6.0.0-beta.2.tgz#8314b61c58e19d19fd4881871f4f59f3350473d1"
+  integrity sha512-YKPcgn6877IEb6JjcotrxIingBe/acyz9n4e3KL84OKZXE2x9nRcwa5A2LxY0KZG0OIgEc3uXDz4QrGS2tOKTw==
   dependencies:
     reserved-words "^0.1.2"
 
-shr-expand@^6.0.0-beta.1:
-  version "6.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-6.0.0-beta.1.tgz#2ef7ada2c5d5cc390e05216ebba88a160bb3c924"
-  integrity sha512-CQ2zOMQ3cD/8g0F89KfZGNoARzie7fEK4CfCM6Xd8RWMFAIK26gAJN5+M5yqEqghxCqt9RFvQP/WnmBL2mopgA==
+shr-expand@^6.0.0-beta.2:
+  version "6.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-6.0.0-beta.2.tgz#030b6d6c72071b1ca8e171863ad7466b4bd02aab"
+  integrity sha512-XBMSJcg7aeCV0OjNrARDhnYUZ0FInojpNKfjKjBb42lMP4pmEuifY/ErSzXDauJLzUZpV3BuRXQ5XueKau9p3Q==
 
-shr-fhir-export@^6.0.0-beta.1:
-  version "6.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-6.0.0-beta.1.tgz#0d1f0190060119940eabc822ba5460d1af880a58"
-  integrity sha512-Sy4/F0wTBlZOuw96LroWBKNnc96RLpEMqb7PP9UenKC4vosU1F+euLBpDJz9l13elPGzXPApDh9hlGmdqEL3Jg==
+shr-fhir-export@^6.0.0-beta.2:
+  version "6.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-6.0.0-beta.2.tgz#c75fbb78527c1a1a71fcfb7565090bcdc65f601c"
+  integrity sha512-0pynFO3WVUQ0L5oN9CGTtcvzeZHYyZF66MXz2ZqW8uukHlGoM2AtyxftCXLNWyXpsoTOKiiYnXisUS6cRYzKMg==
   dependencies:
     fs-extra "^2.0.0"
     lodash "^4.17.5"
@@ -970,23 +958,22 @@ shr-json-javadoc@^6.0.0-beta.1:
     ncp "^2.0.0"
     showdown "^1.8.6"
 
-shr-json-schema-export@^6.0.0-beta.2:
+shr-json-schema-export@^6.0.0-beta.3:
+  version "6.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/shr-json-schema-export/-/shr-json-schema-export-6.0.0-beta.3.tgz#699b4fcd00170036db2c4292908aae24d64ad33d"
+  integrity sha512-0AWmKusiSaADIcY5z3honxbWsfk7xK39iyZ5fmX/KTCuO+8nGmVFLqCB+jBd2wMKoJZmPS1O/HpwZlO+p5G1ig==
+
+shr-models@^6.0.0-beta.2:
   version "6.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/shr-json-schema-export/-/shr-json-schema-export-6.0.0-beta.2.tgz#aaff08a41ba5c161c160bcce13ce9aa91943cf77"
-  integrity sha512-Z5nJJ9qmR1xkrJMo+gIoWxyLz6fUcBXPfUQTVQYmw68tRy9Bg9MB/JJdfXsoPfa+fDnQJaz8bL0J+U5aKnCrwQ==
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-6.0.0-beta.2.tgz#8a730e43dc3e044e26758d7e7569155207901215"
+  integrity sha512-8VpMawL//uZ5dhXoNCEfVmxBAoPhPtLHdvLDwdedujaFdggqNOKwncn8KsYbJl3FXrnwWKlG8FOMRkEYw9xXBg==
 
-shr-models@^6.0.0-beta.1:
-  version "6.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-6.0.0-beta.1.tgz#52f6c9ff10838820c00d6c4e524b237fb95db646"
-  integrity sha512-M7Iz17rCDXDnJ+Su2FbybikNT/O2fHG50BkS+rH4ydFa/6EgLvhL89VI+o9qG+mot3DRb+gvMStn9n7SVkqkwQ==
-
-shr-text-import@^6.0.0-beta.1:
-  version "6.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/shr-text-import/-/shr-text-import-6.0.0-beta.1.tgz#fc0bd420d2ac70fbfe991d6bc7413dffa6219209"
-  integrity sha512-sqXWkxBF7uhbkoiAGVAME6vkINxh7NdJLIW9H+hSqMrs1qiY9dUCqQWTvy/misCHRnXB3A495mgPKcLKIHHXHw==
+shr-text-import@^6.0.0-beta.2:
+  version "6.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/shr-text-import/-/shr-text-import-6.0.0-beta.2.tgz#865779066ec389f7c66a4213db870debcc7fd244"
+  integrity sha512-zCcqdyGTO6mqUCwpEnITFaCH5g2MTZiY/BtsoSMG/JBPqxw7duVwYsABFDdwQCI/Hv7k2q51kBLy0RfVgO1tLg==
   dependencies:
     antlr4 "~4.6.0"
-    dtrace-provider "^0.8.7"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
This PR introduces support for CIMPL6 import.  The `package.json` properly references beta version of all libraries, but if you wish to test the code directly on your system (not using the npm-published libraries), then run:
```sh
$ ./switch-all-branches cimpl6-import -p
```
Ensure that the results have these projects, with these branches, and no local changes:
```
shr-cli                  [cimpl6-import]
shr-es6-export           [cimpl6-import]
shr-expand               [cimpl6-import]
shr-fhir-export          [cimpl6-import]
shr-grammar              [cimpl6-import]
shr-json-javadoc         [cimpl6-import]
shr-json-schema-export   [cimpl6-import]
shr-models               [cimpl6-import]
shr-test-helpers         [cimpl6-import]
shr-text-import          [cimpl6-import]
shr_spec                 [dev6]
```
(It's ok if you also have some of the projects we don't support anymore -- but you need the ones above at a minimum).

As noted above, you also need the `dev6` branch of `shr_spec`.

From the CLI, do a full rebuild of everything:
```sh
$ ./rebuild-all
```
Then link all the projects:
```sh
$ ./yarn-link-all
```

After this you should be able to successfully import CIMPL6 source (**but note: there are known errors reported by the shr-es6-export**).  For example:
```sh
node . -l error -c ig-all-r4-config.json ../shr_spec/spec/
```

On my system, this results in:
```
------------------------------------------------------------
Elapsed time: 105.25s
1370 errors (shr-es6-export)
128 warnings (shr-text-input, shr-fhir-export, shr-json-schema-export)
------------------------------------------------------------
```

Check the results in `out` manually and/or try running the FHIR IG publisher on the IG source (but note that it does not work from behind the firewall).

Marking as a DRAFT PR because all versions will need to be bumped to non-beta versions upon approval.