### PR TITLE
v6.0.1 (FHIR fixes / updates)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-cli",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Command-line interface for SHR tools",
   "author": "",
   "license": "Apache-2.0",
@@ -24,7 +24,7 @@
     "mkdirp": "^0.5.1",
     "shr-es6-export": "^6.0.0",
     "shr-expand": "^6.0.0",
-    "shr-fhir-export": "^6.0.0",
+    "shr-fhir-export": "^6.0.1",
     "shr-json-javadoc": "^6.0.0",
     "shr-json-schema-export": "^6.0.0",
     "shr-models": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -940,10 +940,10 @@ shr-expand@^6.0.0:
   resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-6.0.0.tgz#a2072f971e19b9f221e012c0056ee389a78633d7"
   integrity sha512-zzjli5uVY23J4jHnr5Cr+iLkZ7+6RsHk3kQMksBPUR4ly96NXlCRgillJ3IszbdP3dHpBuWymcrAOjyz4C/lRA==
 
-shr-fhir-export@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-6.0.0.tgz#61cd6e1b08721514950f293a53fbd162f93e236c"
-  integrity sha512-ZNFnkxOvb26Rq2lIvXsuVSnoPfZsVsCgim7BrytqiNUK0jUXnvSa8oOomXYAILVKb631AK3KCMr3ZQ47ZvKcIQ==
+shr-fhir-export@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-6.0.1.tgz#2e54a1cab1ff49f937b529a1a95d0876cf4fd162"
+  integrity sha512-My2z/NP+Qqbysa/F8qKInx/DfmVsTLURKhOGR4dAucIEyIMYkMzFhMjhlSeTFoL9HaKfISmWzc3pvKur7/nYcQ==
   dependencies:
     fs-extra "^2.0.0"
     lodash "^4.17.5"


### PR DESCRIPTION
Version 6.0.1 contains the following fixes and enhancements:

* Fix broken value set URLs for R4-style URLs with versions appended (e.g., `|4.0.0` at the end)
* Change primary selection strategy for extensions so that any extensions in the selected namespace will be listed (in addition to extensions used by profiles in the primary namespace)
* Adds support for the [package-list.json](http://wiki.hl7.org/index.php?title=FHIR_IG_PackageList_doco) file required for HL7 IGs.  You can indicate the name of your file via `config.implementationGuide.packageList` or it defaults to `package-list.json` (HL7 IGs only).  If the file does not exist, it will create a starter file for you.
* Adds the history link to the ig control file (as required for HL7 IGs).
* Updates US core source to latest definitions (as of June 4, 2019).