### PR TITLE
Make ES6 export opt-in

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ before_install:
   - git clone https://github.com/standardhealth/shr_spec.git
   - git -C ./shr_spec checkout dev6
 script:
-  - node . -s es6 shr_spec/spec/
+  - node . shr_spec/spec/

--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ $ node . --help
 
     -l, --log-level <level>  the console log level <fatal,error,warn,info,debug,trace> (default: info)
     -m, --log-mode <mode>    the console log mode <short,long,json,off> (default: short)
-    -s, --skip <feature>     skip an export feature <fhir,cimcore,json-schema,es6,model-doc,data-dict,all> (default: <none>)
+    -s, --skip <feature>     skip an export feature <fhir,cimcore,json-schema,model-doc,data-dict,all> (default: <none>)
     -o, --out <out>          the path to the output folder (default: out)
     -c, --config <config>    the name of the config file (default: config.json)
     -d, --duplicate          show duplicate error messages (default: false)
+    -j, --export-es6         export ES6 JavaScript classes (experimental, default: false)
     -i, --import-cimcore     import CIMCORE files instead of CIMPL (default: false)
     -h, --help               output usage information
 ```

--- a/app.js
+++ b/app.js
@@ -32,10 +32,11 @@ program
   .usage('<path-to-shr-defs> [options]')
   .option('-l, --log-level <level>', 'the console log level <fatal,error,warn,info,debug,trace>', /^(fatal|error|warn|info|debug|trace)$/i, 'info')
   .option('-m, --log-mode <mode>', 'the console log mode <short,long,json,off>', /^(short|long|json|off)$/i, 'short')
-  .option('-s, --skip <feature>', 'skip an export feature <fhir,cimcore,json-schema,es6,model-doc,data-dict,all>', collect, [])
+  .option('-s, --skip <feature>', 'skip an export feature <fhir,cimcore,json-schema,model-doc,data-dict,all>', collect, [])
   .option('-o, --out <out>', `the path to the output folder`, path.join('.', 'out'))
   .option('-c, --config <config>', 'the name of the config file', 'config.json')
   .option('-d, --duplicate', 'show duplicate error messages (default: false)')
+  .option('-j, --export-es6', 'export ES6 JavaScript classes (experimental, default: false)')
   .option('-i, --import-cimcore', 'import CIMCORE files instead of CIMPL (default: false)')
   .arguments('<path-to-shr-defs>')
   .action(function (pathToShrDefs) {
@@ -51,7 +52,6 @@ if (typeof input === 'undefined') {
 // Process the skip flags
 const doFHIR = program.skip.every(a => a.toLowerCase() != 'fhir' && a.toLowerCase() != 'all');
 const doJSONSchema = program.skip.every(a => a.toLowerCase() != 'json-schema' && a.toLowerCase() != 'all');
-const doES6 = program.skip.every(a => a.toLowerCase() != 'es6' && a.toLowerCase() != 'all');
 const doModelDoc = program.skip.every(a => a.toLowerCase() != 'model-doc' && a.toLowerCase() != 'all');
 const doCIMCORE = program.skip.every(a => a.toLowerCase() != 'cimcore' && a.toLowerCase() != 'all');
 const doDD = program.skip.every(a => a.toLowerCase() != 'data-dict' && a.toLowerCase() != 'all');
@@ -60,6 +60,7 @@ const doDD = program.skip.every(a => a.toLowerCase() != 'data-dict' && a.toLower
 
 const showDuplicateErrors = program.duplicate;
 const importCimcore = program.importCimcore;
+const doES6 = program.exportEs6;
 
 // Create the output folder if necessary
 mkdirp.sync(program.out);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-cli",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "description": "Command-line interface for SHR tools",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
Since the ES6 export feature is not production-ready, and currently causes many errors, make it OPT-IN.  To run it, pass the `-j` or `--export-es6` flag, otherwise it will not run.