### PR TITLE
Make ES6 export opt-in (5.x branch)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,6 @@ notifications:
     secure: V7hKbKUg0W2M0InbQuYVV/f98FnuMpP+a8cvDWkLsyI4fiHwaPhq0toAoRRRd2j2Jp6AFsvvaFEW4QhbZecs9UDvFNnVWgma/mvZSs8VhnqSONcw7eD+e6ITF5H5DsPGKZ0pKR95msOyLC9OB2LL9vVxnF2uQOM0pHavCDDHptHcMjdbcBytTSuWntnRDbQ3jLhJfjzi2bjOmgr64XqEtu/0KjqaokEB4p34N9UmybLtYYrQJ+gy7TjeT1K0BDotSe9DmklCJbW51Jok3kKeNHzgymn3AHMEIo6JGY83GwHllba6SIieYnjrCjrtKtDMcxBXOxM1IGYfAEgZvXZ42SW3xHfVh6xOz/wnV8uoaqm5fpTCjQ2Owv0fOKf4Ru/4FMuX0XyVeEKDyBEtKk1O86s5XEX+m+r9vGTxi4K1I4FUq62/pqwxSeNKfoBlWixQUrHOkIn9/xhasDhAFDGOIqyTlOMAyLtpZTYTX1+XNRgFTbVsNHPlmWUsDX1Sg+h2pd5pQAIUU3pfbzOZI0bjYfSB40VOJCnvffU4PozonTa1rjEB7X1zFHIR1Xvn8Mka/MdbPYzgEmDrhFrXCUsznhhIp4GreYisAIYIo0qLxBhZY/YjPjQJA/3Cc2+xU86cyUp8TRFnnQjhfyq8H24S++Delx+X4H39/vmu87/YVgo=
 before_install:
   - git clone https://github.com/standardhealth/shr_spec.git
+  - git -C ./shr_spec checkout dev5
 script:
   - node . shr_spec/spec/

--- a/README.md
+++ b/README.md
@@ -37,12 +37,13 @@ $ node . --help
 
     -l, --log-level <level>  the console log level <fatal,error,warn,info,debug,trace> (default: info)
     -m, --log-mode <mode>    the console log mode <short,long,json,off> (default: short)
-    -s, --skip <feature>     skip an export feature <fhir,json,cimcore,json-schema,es6,model-doc,data-dict,all> (default: <none>)
+    -s, --skip <feature>     skip an export feature <fhir,json,cimcore,json-schema,model-doc,data-dict,all> (default: <none>)
     -a, --adl                run the adl exporter (default: false)
     -o, --out <out>          the path to the output folder (default: out)
     -c, --config <config>    the name of the config file (default: config.json)
     -d, --duplicate          show duplicate error messages (default: false)
     -i, --import-cimcore     import CIMCORE files instead of CIMPL (default: false)
+    -j, --export-es6         export ES6 JavaScript classes (experimental, default: false)
     -6, --export-cimpl-6     export CIMPL 6 files generated  from input (default: false)
     -h, --help               output usage information
 ```
@@ -106,7 +107,7 @@ When using this command-line interface and IG publisher, the general order of op
 
 1. The command-line interface (CLI) imports SHR definitions that have been written (as in the [shr_spec](https://github.com/standardhealth/shr_spec) repo) and parses them through a text importer.
 2. CLI applies filters, according to the `filterStrategy` (see below).
-3. CLI exports the filtered SHR definitions into desired formats, such as ES6, JSON, FHIR, etc. The exports can be selected through command line options, as explained above.
+3. CLI exports the filtered SHR definitions into desired formats, such as FHIR, JSON-Schema, ES6 etc. The exports can be selected through command line options, as explained above.
 4. (separate, optional step) The IG publisher takes the SHR FHIR export and generates an IG from the information in these files, following the `implementationGuide` configuration (see below).
 
 To control this process, CLI requires a configuration file. Configuration files *must* be valid JSON, have at least the `projectName` property, and use the `.json` file extension. The configuration file must be located in the path to the SHR specification definitions.

--- a/app.js
+++ b/app.js
@@ -34,12 +34,13 @@ program
   .usage('<path-to-shr-defs> [options]')
   .option('-l, --log-level <level>', 'the console log level <fatal,error,warn,info,debug,trace>', /^(fatal|error|warn|info|debug|trace)$/i, 'info')
   .option('-m, --log-mode <mode>', 'the console log mode <short,long,json,off>', /^(short|long|json|off)$/i, 'short')
-  .option('-s, --skip <feature>', 'skip an export feature <fhir,json,cimcore,json-schema,es6,model-doc,data-dict,all>', collect, [])
+  .option('-s, --skip <feature>', 'skip an export feature <fhir,json,cimcore,json-schema,model-doc,data-dict,all>', collect, [])
   .option('-a, --adl', 'run the adl exporter (default: false)')
   .option('-o, --out <out>', `the path to the output folder`, path.join('.', 'out'))
   .option('-c, --config <config>', 'the name of the config file', 'config.json')
   .option('-d, --duplicate', 'show duplicate error messages (default: false)')
   .option('-i, --import-cimcore', 'import CIMCORE files instead of CIMPL (default: false)')
+  .option('-j, --export-es6', 'export ES6 JavaScript classes (experimental, default: false)')
   .option('-6, --export-cimpl-6', 'export CIMPL 6 files generated  from input (default: false)')
   .arguments('<path-to-shr-defs>')
   .action(function (pathToShrDefs) {
@@ -56,7 +57,6 @@ if (typeof input === 'undefined') {
 const doFHIR = program.skip.every(a => a.toLowerCase() != 'fhir' && a.toLowerCase() != 'all');
 const doJSON = program.skip.every(a => a.toLowerCase() != 'json' && a.toLowerCase() != 'all');
 const doJSONSchema = program.skip.every(a => a.toLowerCase() != 'json-schema' && a.toLowerCase() != 'all');
-const doES6 = program.skip.every(a => a.toLowerCase() != 'es6' && a.toLowerCase() != 'all');
 const doModelDoc = program.skip.every(a => a.toLowerCase() != 'model-doc' && a.toLowerCase() != 'all');
 const doCIMCORE = program.skip.every(a => a.toLowerCase() != 'cimcore' && a.toLowerCase() != 'all');
 const doDD = program.skip.every(a => a.toLowerCase() != 'data-dict' && a.toLowerCase() != 'all');
@@ -66,6 +66,7 @@ const doADL = program.adl;
 
 // Process the CIMPL 6 export flag
 const doCIMPL6 = program.exportCimpl6;
+const doES6 = program.exportEs6;
 
 // Process the de-duplicate error flag
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-cli",
-  "version": "5.20.1",
+  "version": "5.20.2",
   "description": "Command-line interface for SHR tools",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
Since the ES6 export feature is not production-ready, and currently causes many errors, make it OPT-IN.  To run it, pass the `-j` or `--export-es6` flag, otherwise it will not run.