### PR TITLE
Handling FHIR deps

### DIFF
--- a/app.js
+++ b/app.js
@@ -145,7 +145,7 @@ let specifications;
 let expSpecifications;
 if (!importCimcore) {
   specifications = shrTI.importFromFilePath(input, configSpecifications);
-  expSpecifications = shrEx.expand(specifications, shrFE);
+  expSpecifications = shrEx.expand(specifications, configSpecifications, shrFE);
 } else {
   [configSpecifications, expSpecifications] = shrTI.importCIMCOREFromFilePath(input);
 }

--- a/app.js
+++ b/app.js
@@ -145,6 +145,7 @@ let specifications;
 let expSpecifications;
 if (!importCimcore) {
   specifications = shrTI.importFromFilePath(input, configSpecifications);
+  configSpecifications.specPath = input;
   expSpecifications = shrEx.expand(specifications, configSpecifications, shrFE);
 } else {
   [configSpecifications, expSpecifications] = shrTI.importCIMCOREFromFilePath(input);


### PR DESCRIPTION
This is 1 of 3 PRs that add functionality to handle FHIR dependencies specified by the user. The other PRs are:
* shr-expand: https://github.com/standardhealth/shr-expand/pull/50
* shr-fhir-export: https://github.com/standardhealth/shr-fhir-export/pull/166